### PR TITLE
Added support for xxHash32

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,5 @@ typings/
 
 # next.js build output
 .next
+
+package-lock.json

--- a/README.md
+++ b/README.md
@@ -43,10 +43,10 @@ app.listen(3000)
 
 ## Acknowledgements
 
-The fnv1a logic was forked from https://github.com/sindresorhus/fnv1a
+The fnv1a logic was forked from [sindresorhus/fnv1a](https://github.com/sindresorhus/fnv1a)
 and adapted to support buffers.
 
-The xxHash32 algorithm is implemented in pure JavaScript and it's coming through a module written by Jason3S: https://github.com/Jason3S/xxhash.
+The xxHash32 algorithm is implemented in pure JavaScript and it's coming through a module written by Jason3S: [Jason3S/xxhash](https://github.com/Jason3S/xxhash).
 
 ## Benchmarks
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,9 @@ app.listen(3000)
 The fnv1a logic was forked from [sindresorhus/fnv1a](https://github.com/sindresorhus/fnv1a)
 and adapted to support buffers.
 
-The xxHash32 algorithm is implemented in pure JavaScript and it's coming through a module written by Jason3S: [Jason3S/xxhash](https://github.com/Jason3S/xxhash).
+The xxHash32 algorithm is implemented in pure JavaScript and it's a modified
+version of a module originally written by Jason3S:
+[Jason3S/xxhash](https://github.com/Jason3S/xxhash).
 
 ## Benchmarks
 

--- a/README.md
+++ b/README.md
@@ -38,19 +38,22 @@ app.listen(3000)
 
 ## Plugin Options
 
-* `algorithm`: all hashing algorithm that Node.js support, and
-  `'fnv1a'`. Default: `'fnv1a'`.
+* `algorithm`: all hashing algorithm that Node.js support, with the addition of
+  `'fnv1a'` and `'xxhash'`. Default: `'fnv1a'`.
 
 ## Acknowledgements
 
 The fnv1a logic was forked from https://github.com/sindresorhus/fnv1a
 and adapted to support buffers.
 
+The xxHash32 algorithm is implemented in pure JavaScript and it's coming through a module written by Jason3S: https://github.com/Jason3S/xxhash.
+
 ## Benchmarks
 
 * `md5` algorithm: 29679 req/s (median)
 * `sha1` algorithm: 25935 req/s (median)
 * *`fnv1a` algorithm: 42943 req/s (median)*
+* `xxhash` algorithm: TBD
 
 No etag generation: 45471 req/s (median)
 

--- a/benchmarks/printReport.js
+++ b/benchmarks/printReport.js
@@ -12,7 +12,7 @@ module.exports = function printReport (results) {
 
       let i = 0
       for (let b of sorted) {
-        console.log(`  ${++i}. ${b.name}\t${b.results.requests.mean} req/sec${b.results.errors ? `(${b.results.errors} errors - ${b.results.timeouts})`}`)
+        console.log(`  ${++i}. ${b.name}\t${b.results.requests.mean} req/sec${b.results.errors ? ` (${b.results.errors} errors - ${b.results.timeouts})` : ''}`)
       }
       console.log()
     }

--- a/benchmarks/printReport.js
+++ b/benchmarks/printReport.js
@@ -1,0 +1,20 @@
+'use strict'
+
+module.exports = function printReport(results) {
+  for (let group of Object.keys(results)) {
+    console.log(`\n${group}\n${'-'.repeat(group.length)}\n`)
+    for (let subgroup of Object.keys(results[group])) {
+      console.log(`  ${subgroup}\n  ${'-'.repeat(subgroup.length)}`)
+
+      // sort the results by mean of req/sec
+      const sorted = (results[group][subgroup])
+        .sort((a, b) => b.results.requests.mean - a.results.requests.mean)
+
+      let i = 0
+      for (let b of sorted) {
+        console.log(`  ${++i}. ${b.name}\t${b.results.requests.mean} req/sec`)
+      }
+      console.log()
+    }
+  }
+}

--- a/benchmarks/printReport.js
+++ b/benchmarks/printReport.js
@@ -1,6 +1,6 @@
 'use strict'
 
-module.exports = function printReport(results) {
+module.exports = function printReport (results) {
   for (let group of Object.keys(results)) {
     console.log(`\n${group}\n${'-'.repeat(group.length)}\n`)
     for (let subgroup of Object.keys(results[group])) {

--- a/benchmarks/printReport.js
+++ b/benchmarks/printReport.js
@@ -12,7 +12,7 @@ module.exports = function printReport (results) {
 
       let i = 0
       for (let b of sorted) {
-        console.log(`  ${++i}. ${b.name}\t${b.results.requests.mean} req/sec${b.results.errors ? ` (${b.results.errors} errors - ${b.results.timeouts})` : ''}`)
+        console.log(`  ${++i}. ${b.name}\t${b.results.requests.mean} req/sec${b.results.errors ? ` (${b.results.errors} errors - ${b.results.timeouts} timeouts)` : ''}`)
       }
       console.log()
     }

--- a/benchmarks/printReport.js
+++ b/benchmarks/printReport.js
@@ -12,7 +12,7 @@ module.exports = function printReport (results) {
 
       let i = 0
       for (let b of sorted) {
-        console.log(`  ${++i}. ${b.name}\t${b.results.requests.mean} req/sec`)
+        console.log(`  ${++i}. ${b.name}\t${b.results.requests.mean} req/sec${b.results.errors ? `(${b.results.errors} errors - ${b.results.timeouts})`}`)
       }
       console.log()
     }

--- a/benchmarks/run.js
+++ b/benchmarks/run.js
@@ -33,8 +33,8 @@ const shoot = (port) => new Promise((resolve) => {
   const opts = {
     url: `http://localhost:${port}/`,
     connections: 100,
-    pipelining: 10,
-    duration: 40
+    pipelining: 4,
+    duration: 30
   }
 
   currentBenchmark = autocannon(opts)

--- a/benchmarks/run.js
+++ b/benchmarks/run.js
@@ -34,7 +34,8 @@ const shoot = (port) => new Promise((resolve) => {
     url: `http://localhost:${port}/`,
     connections: 100,
     pipelining: 4,
-    duration: 30
+    duration: 30,
+    timeout: 30
   }
 
   currentBenchmark = autocannon(opts)

--- a/benchmarks/run.js
+++ b/benchmarks/run.js
@@ -1,0 +1,103 @@
+'use strict'
+
+const { writeFileSync } = require('fs')
+const { spawn } = require('child_process')
+const { resolve, join } = require('path')
+const autocannon = require('autocannon')
+const testCases = require('./testCases')
+const printReport = require('./printReport')
+
+const serverPath = resolve(join(__dirname, 'server.js'))
+
+const pauseFor = (ms) => new Promise((resolve) => {
+  setTimeout(resolve, ms)
+})
+
+let currentServerInstance = null
+const startServerFor = (test, port) => {
+  const env = Object.assign({}, test.options, { PORT: port, PATH: process.env.PATH })
+  currentServerInstance = spawn(
+    serverPath,
+    [],
+    {
+      env,
+      stdio: [ 'ignore', 'ignore', 'ignore' ]
+    }
+  )
+
+  return currentServerInstance
+}
+
+let currentBenchmark = null
+const shoot = (port) => new Promise((resolve) => {
+  const opts = {
+    url: `http://localhost:${port}/`,
+    connections: 100,
+    pipelining: 10,
+    duration: 40
+  }
+
+  currentBenchmark = autocannon(opts)
+  currentBenchmark.once('done', resolve)
+  autocannon.track(currentBenchmark, { renderResultsTable: false })
+})
+
+async function run() {
+  const results = {}
+  let port = 3000
+
+  for (let test of testCases) {
+    port++
+    console.log(`🚗 ${test.name} (${test.group}, ${test.subgroup}) 🚗`)
+
+    // run server in the background
+    const server = startServerFor(test, port)
+
+    // wait 1 second to make sure the server is listening
+    await pauseFor(1000)
+
+    if (server.exitCode !== null) {
+      console.error(`Server exited with exit code ${server.exitCode}`)
+      continue
+    }
+
+    // run autocannon and collect results
+    const benchResults = await shoot(port)
+    console.log(`> ${benchResults.requests.mean} req/sec - Latency: ${benchResults.latency.mean}ms\n\n`)
+
+    if (typeof results[test.group] === 'undefined') {
+      results[test.group] = {}
+    }
+    if (typeof results[test.group][test.subgroup] === 'undefined') {
+      results[test.group][test.subgroup] = []
+    }
+    results[test.group][test.subgroup].push({ name: test.name, results: benchResults })
+
+    // shutdown the server
+    server.kill('SIGINT')
+
+    // wait for the server to be shutdown
+    await pauseFor(1000)
+  }
+
+  // save and display results
+  writeFileSync('benchResults.json', JSON.stringify(results, null, 2))
+  printReport(results)
+}
+
+process.once('SIGINT', () => {
+  console.log('\n\n🛑 Benchmark stopped!')
+
+  // make sure current server is killed if the main process exits
+  if (currentServerInstance && !currentServerInstance.killed) {
+    currentServerInstance.kill('SIGINT')
+  }
+
+  if (currentBenchmark) {
+    currentBenchmark.stop()
+  }
+
+  process.exit(1)
+})
+
+run()

--- a/benchmarks/run.js
+++ b/benchmarks/run.js
@@ -21,7 +21,8 @@ const startServerFor = (test, port) => {
     [],
     {
       env,
-      stdio: [ 'ignore', 'ignore', 'ignore' ]
+      stdio: [ 'ignore', 'ignore', 'ignore' ],
+      shell: true
     }
   )
 

--- a/benchmarks/run.js
+++ b/benchmarks/run.js
@@ -42,7 +42,7 @@ const shoot = (port) => new Promise((resolve) => {
   autocannon.track(currentBenchmark, { renderResultsTable: false })
 })
 
-async function run() {
+async function run () {
   const results = {}
   let port = 3000
 

--- a/benchmarks/server.js
+++ b/benchmarks/server.js
@@ -1,0 +1,43 @@
+#!/usr/bin/env node
+
+'use strict'
+
+const Fastify = require('fastify')
+const Etag = require('../')
+
+const port = Number(process.env.PORT) || 3000
+const algorithm = process.env.ALGORITHM
+const contentFormat = process.env.CONTENT_FORMAT
+const contentSize = Number(process.env.CONTENT_SIZE)
+
+const contentBase = 'Fastify 😎 is ✌️ GREAT 👾 and 🧙‍♀️ it 🗣 rocks 🤘 '
+
+let content = contentBase
+  .repeat(Math.ceil(contentSize / contentBase.length))
+  .substr(0, contentSize)
+
+if (contentFormat === 'buffer') {
+  content = Buffer.from(content)
+}
+
+async function run() {
+  const app = Fastify()
+
+  if (algorithm) {
+    app.register(Etag, { algorithm })
+  }
+
+  app.get('/', async (req, reply) => {
+    return content
+  })
+
+  try {
+    await app.listen(port)
+    console.log(`Server started on port ${port}`)
+  } catch (err) {
+    console.error(`Cannot start server: ${err}`)
+    process.exit(1)
+  }
+}
+
+run()

--- a/benchmarks/server.js
+++ b/benchmarks/server.js
@@ -20,7 +20,7 @@ if (contentFormat === 'buffer') {
   content = Buffer.from(content)
 }
 
-async function run() {
+async function run () {
   const app = Fastify()
 
   if (algorithm) {

--- a/benchmarks/testCases.js
+++ b/benchmarks/testCases.js
@@ -7,82 +7,82 @@ const testCases = [
   // no e-tag
   { name: 'No etag', group: '32 bytes', subgroup: 'string', options: { CONTENT_FORMAT: 'string', CONTENT_SIZE: 32 } },
   { name: 'No etag', group: '32 bytes', subgroup: 'buffer', options: { CONTENT_FORMAT: 'buffer', CONTENT_SIZE: 32 } },
-  { name: 'No etag', group: '4 kb', subgroup: 'string', options: { CONTENT_FORMAT: 'string', CONTENT_SIZE: kb(4) } },
-  { name: 'No etag', group: '4 kb', subgroup: 'buffer', options: { CONTENT_FORMAT: 'buffer', CONTENT_SIZE: kb(4) } },
-  { name: 'No etag', group: '4 Mb', subgroup: 'string', options: { CONTENT_FORMAT: 'string', CONTENT_SIZE: mb(4) } },
-  { name: 'No etag', group: '4 Mb', subgroup: 'buffer', options: { CONTENT_FORMAT: 'buffer', CONTENT_SIZE: mb(4) } },
+  { name: 'No etag', group: '2 kb', subgroup: 'string', options: { CONTENT_FORMAT: 'string', CONTENT_SIZE: kb(2) } },
+  { name: 'No etag', group: '2 kb', subgroup: 'buffer', options: { CONTENT_FORMAT: 'buffer', CONTENT_SIZE: kb(2) } },
+  { name: 'No etag', group: '2 Mb', subgroup: 'string', options: { CONTENT_FORMAT: 'string', CONTENT_SIZE: mb(2) } },
+  { name: 'No etag', group: '2 Mb', subgroup: 'buffer', options: { CONTENT_FORMAT: 'buffer', CONTENT_SIZE: mb(2) } },
 
   // fnv1a
   { name: 'fnv1a', group: '32 bytes', subgroup: 'string', options: { ALGORITHM: 'fnv1a', CONTENT_FORMAT: 'string', CONTENT_SIZE: 32 } },
   { name: 'fnv1a', group: '32 bytes', subgroup: 'buffer', options: { ALGORITHM: 'fnv1a', CONTENT_FORMAT: 'buffer', CONTENT_SIZE: 32 } },
-  { name: 'fnv1a', group: '4 kb', subgroup: 'string', options: { ALGORITHM: 'fnv1a', CONTENT_FORMAT: 'string', CONTENT_SIZE: kb(4) } },
-  { name: 'fnv1a', group: '4 kb', subgroup: 'buffer', options: { ALGORITHM: 'fnv1a', CONTENT_FORMAT: 'buffer', CONTENT_SIZE: kb(4) } },
-  { name: 'fnv1a', group: '4 Mb', subgroup: 'string', options: { ALGORITHM: 'fnv1a', CONTENT_FORMAT: 'string', CONTENT_SIZE: mb(4) } },
-  { name: 'fnv1a', group: '4 Mb', subgroup: 'buffer', options: { ALGORITHM: 'fnv1a', CONTENT_FORMAT: 'buffer', CONTENT_SIZE: mb(4) } },
+  { name: 'fnv1a', group: '2 kb', subgroup: 'string', options: { ALGORITHM: 'fnv1a', CONTENT_FORMAT: 'string', CONTENT_SIZE: kb(2) } },
+  { name: 'fnv1a', group: '2 kb', subgroup: 'buffer', options: { ALGORITHM: 'fnv1a', CONTENT_FORMAT: 'buffer', CONTENT_SIZE: kb(2) } },
+  { name: 'fnv1a', group: '2 Mb', subgroup: 'string', options: { ALGORITHM: 'fnv1a', CONTENT_FORMAT: 'string', CONTENT_SIZE: mb(2) } },
+  { name: 'fnv1a', group: '2 Mb', subgroup: 'buffer', options: { ALGORITHM: 'fnv1a', CONTENT_FORMAT: 'buffer', CONTENT_SIZE: mb(2) } },
 
   // xxhash
   { name: 'xxhash', group: '32 bytes', subgroup: 'string', options: { ALGORITHM: 'xxhash', CONTENT_FORMAT: 'string', CONTENT_SIZE: 32 } },
   { name: 'xxhash', group: '32 bytes', subgroup: 'buffer', options: { ALGORITHM: 'xxhash', CONTENT_FORMAT: 'buffer', CONTENT_SIZE: 32 } },
-  { name: 'xxhash', group: '4 kb', subgroup: 'string', options: { ALGORITHM: 'xxhash', CONTENT_FORMAT: 'string', CONTENT_SIZE: kb(4) } },
-  { name: 'xxhash', group: '4 kb', subgroup: 'buffer', options: { ALGORITHM: 'xxhash', CONTENT_FORMAT: 'buffer', CONTENT_SIZE: kb(4) } },
-  { name: 'xxhash', group: '4 Mb', subgroup: 'string', options: { ALGORITHM: 'xxhash', CONTENT_FORMAT: 'string', CONTENT_SIZE: mb(4) } },
-  { name: 'xxhash', group: '4 Mb', subgroup: 'buffer', options: { ALGORITHM: 'xxhash', CONTENT_FORMAT: 'buffer', CONTENT_SIZE: mb(4) } },
+  { name: 'xxhash', group: '2 kb', subgroup: 'string', options: { ALGORITHM: 'xxhash', CONTENT_FORMAT: 'string', CONTENT_SIZE: kb(2) } },
+  { name: 'xxhash', group: '2 kb', subgroup: 'buffer', options: { ALGORITHM: 'xxhash', CONTENT_FORMAT: 'buffer', CONTENT_SIZE: kb(2) } },
+  { name: 'xxhash', group: '2 Mb', subgroup: 'string', options: { ALGORITHM: 'xxhash', CONTENT_FORMAT: 'string', CONTENT_SIZE: mb(2) } },
+  { name: 'xxhash', group: '2 Mb', subgroup: 'buffer', options: { ALGORITHM: 'xxhash', CONTENT_FORMAT: 'buffer', CONTENT_SIZE: mb(2) } },
 
   // md4
   { name: 'md4', group: '32 bytes', subgroup: 'string', options: { ALGORITHM: 'md4', CONTENT_FORMAT: 'string', CONTENT_SIZE: 32 } },
   { name: 'md4', group: '32 bytes', subgroup: 'buffer', options: { ALGORITHM: 'md4', CONTENT_FORMAT: 'buffer', CONTENT_SIZE: 32 } },
-  { name: 'md4', group: '4 kb', subgroup: 'string', options: { ALGORITHM: 'md4', CONTENT_FORMAT: 'string', CONTENT_SIZE: kb(4) } },
-  { name: 'md4', group: '4 kb', subgroup: 'buffer', options: { ALGORITHM: 'md4', CONTENT_FORMAT: 'buffer', CONTENT_SIZE: kb(4) } },
-  { name: 'md4', group: '4 Mb', subgroup: 'string', options: { ALGORITHM: 'md4', CONTENT_FORMAT: 'string', CONTENT_SIZE: mb(4) } },
-  { name: 'md4', group: '4 Mb', subgroup: 'buffer', options: { ALGORITHM: 'md4', CONTENT_FORMAT: 'buffer', CONTENT_SIZE: mb(4) } },
+  { name: 'md4', group: '2 kb', subgroup: 'string', options: { ALGORITHM: 'md4', CONTENT_FORMAT: 'string', CONTENT_SIZE: kb(2) } },
+  { name: 'md4', group: '2 kb', subgroup: 'buffer', options: { ALGORITHM: 'md4', CONTENT_FORMAT: 'buffer', CONTENT_SIZE: kb(2) } },
+  { name: 'md4', group: '2 Mb', subgroup: 'string', options: { ALGORITHM: 'md4', CONTENT_FORMAT: 'string', CONTENT_SIZE: mb(2) } },
+  { name: 'md4', group: '2 Mb', subgroup: 'buffer', options: { ALGORITHM: 'md4', CONTENT_FORMAT: 'buffer', CONTENT_SIZE: mb(2) } },
 
   // md5
   { name: 'md5', group: '32 bytes', subgroup: 'string', options: { ALGORITHM: 'md5', CONTENT_FORMAT: 'string', CONTENT_SIZE: 32 } },
   { name: 'md5', group: '32 bytes', subgroup: 'buffer', options: { ALGORITHM: 'md5', CONTENT_FORMAT: 'buffer', CONTENT_SIZE: 32 } },
-  { name: 'md5', group: '4 kb', subgroup: 'string', options: { ALGORITHM: 'md5', CONTENT_FORMAT: 'string', CONTENT_SIZE: kb(4) } },
-  { name: 'md5', group: '4 kb', subgroup: 'buffer', options: { ALGORITHM: 'md5', CONTENT_FORMAT: 'buffer', CONTENT_SIZE: kb(4) } },
-  { name: 'md5', group: '4 Mb', subgroup: 'string', options: { ALGORITHM: 'md5', CONTENT_FORMAT: 'string', CONTENT_SIZE: mb(4) } },
-  { name: 'md5', group: '4 Mb', subgroup: 'buffer', options: { ALGORITHM: 'md5', CONTENT_FORMAT: 'buffer', CONTENT_SIZE: mb(4) } },
+  { name: 'md5', group: '2 kb', subgroup: 'string', options: { ALGORITHM: 'md5', CONTENT_FORMAT: 'string', CONTENT_SIZE: kb(2) } },
+  { name: 'md5', group: '2 kb', subgroup: 'buffer', options: { ALGORITHM: 'md5', CONTENT_FORMAT: 'buffer', CONTENT_SIZE: kb(2) } },
+  { name: 'md5', group: '2 Mb', subgroup: 'string', options: { ALGORITHM: 'md5', CONTENT_FORMAT: 'string', CONTENT_SIZE: mb(2) } },
+  { name: 'md5', group: '2 Mb', subgroup: 'buffer', options: { ALGORITHM: 'md5', CONTENT_FORMAT: 'buffer', CONTENT_SIZE: mb(2) } },
 
   // sha1
   { name: 'sha1', group: '32 bytes', subgroup: 'string', options: { ALGORITHM: 'sha1', CONTENT_FORMAT: 'string', CONTENT_SIZE: 32 } },
   { name: 'sha1', group: '32 bytes', subgroup: 'buffer', options: { ALGORITHM: 'sha1', CONTENT_FORMAT: 'buffer', CONTENT_SIZE: 32 } },
-  { name: 'sha1', group: '4 kb', subgroup: 'string', options: { ALGORITHM: 'sha1', CONTENT_FORMAT: 'string', CONTENT_SIZE: kb(4) } },
-  { name: 'sha1', group: '4 kb', subgroup: 'buffer', options: { ALGORITHM: 'sha1', CONTENT_FORMAT: 'buffer', CONTENT_SIZE: kb(4) } },
-  { name: 'sha1', group: '4 Mb', subgroup: 'string', options: { ALGORITHM: 'sha1', CONTENT_FORMAT: 'string', CONTENT_SIZE: mb(4) } },
-  { name: 'sha1', group: '4 Mb', subgroup: 'buffer', options: { ALGORITHM: 'sha1', CONTENT_FORMAT: 'buffer', CONTENT_SIZE: mb(4) } },
+  { name: 'sha1', group: '2 kb', subgroup: 'string', options: { ALGORITHM: 'sha1', CONTENT_FORMAT: 'string', CONTENT_SIZE: kb(2) } },
+  { name: 'sha1', group: '2 kb', subgroup: 'buffer', options: { ALGORITHM: 'sha1', CONTENT_FORMAT: 'buffer', CONTENT_SIZE: kb(2) } },
+  { name: 'sha1', group: '2 Mb', subgroup: 'string', options: { ALGORITHM: 'sha1', CONTENT_FORMAT: 'string', CONTENT_SIZE: mb(2) } },
+  { name: 'sha1', group: '2 Mb', subgroup: 'buffer', options: { ALGORITHM: 'sha1', CONTENT_FORMAT: 'buffer', CONTENT_SIZE: mb(2) } },
 
   // sha224
   { name: 'sha224', group: '32 bytes', subgroup: 'string', options: { ALGORITHM: 'sha224', CONTENT_FORMAT: 'string', CONTENT_SIZE: 32 } },
   { name: 'sha224', group: '32 bytes', subgroup: 'buffer', options: { ALGORITHM: 'sha224', CONTENT_FORMAT: 'buffer', CONTENT_SIZE: 32 } },
-  { name: 'sha224', group: '4 kb', subgroup: 'string', options: { ALGORITHM: 'sha224', CONTENT_FORMAT: 'string', CONTENT_SIZE: kb(4) } },
-  { name: 'sha224', group: '4 kb', subgroup: 'buffer', options: { ALGORITHM: 'sha224', CONTENT_FORMAT: 'buffer', CONTENT_SIZE: kb(4) } },
-  { name: 'sha224', group: '4 Mb', subgroup: 'string', options: { ALGORITHM: 'sha224', CONTENT_FORMAT: 'string', CONTENT_SIZE: mb(4) } },
-  { name: 'sha224', group: '4 Mb', subgroup: 'buffer', options: { ALGORITHM: 'sha224', CONTENT_FORMAT: 'buffer', CONTENT_SIZE: mb(4) } },
+  { name: 'sha224', group: '2 kb', subgroup: 'string', options: { ALGORITHM: 'sha224', CONTENT_FORMAT: 'string', CONTENT_SIZE: kb(2) } },
+  { name: 'sha224', group: '2 kb', subgroup: 'buffer', options: { ALGORITHM: 'sha224', CONTENT_FORMAT: 'buffer', CONTENT_SIZE: kb(2) } },
+  { name: 'sha224', group: '2 Mb', subgroup: 'string', options: { ALGORITHM: 'sha224', CONTENT_FORMAT: 'string', CONTENT_SIZE: mb(2) } },
+  { name: 'sha224', group: '2 Mb', subgroup: 'buffer', options: { ALGORITHM: 'sha224', CONTENT_FORMAT: 'buffer', CONTENT_SIZE: mb(2) } },
 
   // sha256
   { name: 'sha256', group: '32 bytes', subgroup: 'string', options: { ALGORITHM: 'sha256', CONTENT_FORMAT: 'string', CONTENT_SIZE: 32 } },
   { name: 'sha256', group: '32 bytes', subgroup: 'buffer', options: { ALGORITHM: 'sha256', CONTENT_FORMAT: 'buffer', CONTENT_SIZE: 32 } },
-  { name: 'sha256', group: '4 kb', subgroup: 'string', options: { ALGORITHM: 'sha256', CONTENT_FORMAT: 'string', CONTENT_SIZE: kb(4) } },
-  { name: 'sha256', group: '4 kb', subgroup: 'buffer', options: { ALGORITHM: 'sha256', CONTENT_FORMAT: 'buffer', CONTENT_SIZE: kb(4) } },
-  { name: 'sha256', group: '4 Mb', subgroup: 'string', options: { ALGORITHM: 'sha256', CONTENT_FORMAT: 'string', CONTENT_SIZE: mb(4) } },
-  { name: 'sha256', group: '4 Mb', subgroup: 'buffer', options: { ALGORITHM: 'sha256', CONTENT_FORMAT: 'buffer', CONTENT_SIZE: mb(4) } },
+  { name: 'sha256', group: '2 kb', subgroup: 'string', options: { ALGORITHM: 'sha256', CONTENT_FORMAT: 'string', CONTENT_SIZE: kb(2) } },
+  { name: 'sha256', group: '2 kb', subgroup: 'buffer', options: { ALGORITHM: 'sha256', CONTENT_FORMAT: 'buffer', CONTENT_SIZE: kb(2) } },
+  { name: 'sha256', group: '2 Mb', subgroup: 'string', options: { ALGORITHM: 'sha256', CONTENT_FORMAT: 'string', CONTENT_SIZE: mb(2) } },
+  { name: 'sha256', group: '2 Mb', subgroup: 'buffer', options: { ALGORITHM: 'sha256', CONTENT_FORMAT: 'buffer', CONTENT_SIZE: mb(2) } },
 
   // sha384
   { name: 'sha384', group: '32 bytes', subgroup: 'string', options: { ALGORITHM: 'sha384', CONTENT_FORMAT: 'string', CONTENT_SIZE: 32 } },
   { name: 'sha384', group: '32 bytes', subgroup: 'buffer', options: { ALGORITHM: 'sha384', CONTENT_FORMAT: 'buffer', CONTENT_SIZE: 32 } },
-  { name: 'sha384', group: '4 kb', subgroup: 'string', options: { ALGORITHM: 'sha384', CONTENT_FORMAT: 'string', CONTENT_SIZE: kb(4) } },
-  { name: 'sha384', group: '4 kb', subgroup: 'buffer', options: { ALGORITHM: 'sha384', CONTENT_FORMAT: 'buffer', CONTENT_SIZE: kb(4) } },
-  { name: 'sha384', group: '4 Mb', subgroup: 'string', options: { ALGORITHM: 'sha384', CONTENT_FORMAT: 'string', CONTENT_SIZE: mb(4) } },
-  { name: 'sha384', group: '4 Mb', subgroup: 'buffer', options: { ALGORITHM: 'sha384', CONTENT_FORMAT: 'buffer', CONTENT_SIZE: mb(4) } },
+  { name: 'sha384', group: '2 kb', subgroup: 'string', options: { ALGORITHM: 'sha384', CONTENT_FORMAT: 'string', CONTENT_SIZE: kb(2) } },
+  { name: 'sha384', group: '2 kb', subgroup: 'buffer', options: { ALGORITHM: 'sha384', CONTENT_FORMAT: 'buffer', CONTENT_SIZE: kb(2) } },
+  { name: 'sha384', group: '2 Mb', subgroup: 'string', options: { ALGORITHM: 'sha384', CONTENT_FORMAT: 'string', CONTENT_SIZE: mb(2) } },
+  { name: 'sha384', group: '2 Mb', subgroup: 'buffer', options: { ALGORITHM: 'sha384', CONTENT_FORMAT: 'buffer', CONTENT_SIZE: mb(2) } },
 
   // sha512
   { name: 'sha512', group: '32 bytes', subgroup: 'string', options: { ALGORITHM: 'sha512', CONTENT_FORMAT: 'string', CONTENT_SIZE: 32 } },
   { name: 'sha512', group: '32 bytes', subgroup: 'buffer', options: { ALGORITHM: 'sha512', CONTENT_FORMAT: 'buffer', CONTENT_SIZE: 32 } },
-  { name: 'sha512', group: '4 kb', subgroup: 'string', options: { ALGORITHM: 'sha512', CONTENT_FORMAT: 'string', CONTENT_SIZE: kb(4) } },
-  { name: 'sha512', group: '4 kb', subgroup: 'buffer', options: { ALGORITHM: 'sha512', CONTENT_FORMAT: 'buffer', CONTENT_SIZE: kb(4) } },
-  { name: 'sha512', group: '4 Mb', subgroup: 'string', options: { ALGORITHM: 'sha512', CONTENT_FORMAT: 'string', CONTENT_SIZE: mb(4) } },
-  { name: 'sha512', group: '4 Mb', subgroup: 'buffer', options: { ALGORITHM: 'sha512', CONTENT_FORMAT: 'buffer', CONTENT_SIZE: mb(4) } }
+  { name: 'sha512', group: '2 kb', subgroup: 'string', options: { ALGORITHM: 'sha512', CONTENT_FORMAT: 'string', CONTENT_SIZE: kb(2) } },
+  { name: 'sha512', group: '2 kb', subgroup: 'buffer', options: { ALGORITHM: 'sha512', CONTENT_FORMAT: 'buffer', CONTENT_SIZE: kb(2) } },
+  { name: 'sha512', group: '2 Mb', subgroup: 'string', options: { ALGORITHM: 'sha512', CONTENT_FORMAT: 'string', CONTENT_SIZE: mb(2) } },
+  { name: 'sha512', group: '2 Mb', subgroup: 'buffer', options: { ALGORITHM: 'sha512', CONTENT_FORMAT: 'buffer', CONTENT_SIZE: mb(2) } }
 ]
 
 module.exports = testCases

--- a/benchmarks/testCases.js
+++ b/benchmarks/testCases.js
@@ -1,0 +1,88 @@
+'use strict'
+
+const kb = (val) => val * 1024
+const mb = (val) => val * 1024 * 1024
+
+const testCases = [
+  // no e-tag
+  { name: 'No etag', group: '32 bytes', subgroup: 'string', options: { CONTENT_FORMAT: 'string', CONTENT_SIZE: 32 } },
+  { name: 'No etag', group: '32 bytes', subgroup: 'buffer', options: { CONTENT_FORMAT: 'buffer', CONTENT_SIZE: 32 } },
+  { name: 'No etag', group: '4 kb', subgroup: 'string', options: { CONTENT_FORMAT: 'string', CONTENT_SIZE: kb(4) } },
+  { name: 'No etag', group: '4 kb', subgroup: 'buffer', options: { CONTENT_FORMAT: 'buffer', CONTENT_SIZE: kb(4) } },
+  { name: 'No etag', group: '4 Mb', subgroup: 'string', options: { CONTENT_FORMAT: 'string', CONTENT_SIZE: mb(4) } },
+  { name: 'No etag', group: '4 Mb', subgroup: 'buffer', options: { CONTENT_FORMAT: 'buffer', CONTENT_SIZE: mb(4) } },
+
+  // fnv1a
+  { name: 'fnv1a', group: '32 bytes', subgroup: 'string', options: { ALGORITHM: 'fnv1a', CONTENT_FORMAT: 'string', CONTENT_SIZE: 32 } },
+  { name: 'fnv1a', group: '32 bytes', subgroup: 'buffer', options: { ALGORITHM: 'fnv1a', CONTENT_FORMAT: 'buffer', CONTENT_SIZE: 32 } },
+  { name: 'fnv1a', group: '4 kb', subgroup: 'string', options: { ALGORITHM: 'fnv1a', CONTENT_FORMAT: 'string', CONTENT_SIZE: kb(4) } },
+  { name: 'fnv1a', group: '4 kb', subgroup: 'buffer', options: { ALGORITHM: 'fnv1a', CONTENT_FORMAT: 'buffer', CONTENT_SIZE: kb(4) } },
+  { name: 'fnv1a', group: '4 Mb', subgroup: 'string', options: { ALGORITHM: 'fnv1a', CONTENT_FORMAT: 'string', CONTENT_SIZE: mb(4) } },
+  { name: 'fnv1a', group: '4 Mb', subgroup: 'buffer', options: { ALGORITHM: 'fnv1a', CONTENT_FORMAT: 'buffer', CONTENT_SIZE: mb(4) } },
+
+  // xxhash
+  { name: 'xxhash', group: '32 bytes', subgroup: 'string', options: { ALGORITHM: 'xxhash', CONTENT_FORMAT: 'string', CONTENT_SIZE: 32 } },
+  { name: 'xxhash', group: '32 bytes', subgroup: 'buffer', options: { ALGORITHM: 'xxhash', CONTENT_FORMAT: 'buffer', CONTENT_SIZE: 32 } },
+  { name: 'xxhash', group: '4 kb', subgroup: 'string', options: { ALGORITHM: 'xxhash', CONTENT_FORMAT: 'string', CONTENT_SIZE: kb(4) } },
+  { name: 'xxhash', group: '4 kb', subgroup: 'buffer', options: { ALGORITHM: 'xxhash', CONTENT_FORMAT: 'buffer', CONTENT_SIZE: kb(4) } },
+  { name: 'xxhash', group: '4 Mb', subgroup: 'string', options: { ALGORITHM: 'xxhash', CONTENT_FORMAT: 'string', CONTENT_SIZE: mb(4) } },
+  { name: 'xxhash', group: '4 Mb', subgroup: 'buffer', options: { ALGORITHM: 'xxhash', CONTENT_FORMAT: 'buffer', CONTENT_SIZE: mb(4) } },
+
+  // md4
+  { name: 'md4', group: '32 bytes', subgroup: 'string', options: { ALGORITHM: 'md4', CONTENT_FORMAT: 'string', CONTENT_SIZE: 32 } },
+  { name: 'md4', group: '32 bytes', subgroup: 'buffer', options: { ALGORITHM: 'md4', CONTENT_FORMAT: 'buffer', CONTENT_SIZE: 32 } },
+  { name: 'md4', group: '4 kb', subgroup: 'string', options: { ALGORITHM: 'md4', CONTENT_FORMAT: 'string', CONTENT_SIZE: kb(4) } },
+  { name: 'md4', group: '4 kb', subgroup: 'buffer', options: { ALGORITHM: 'md4', CONTENT_FORMAT: 'buffer', CONTENT_SIZE: kb(4) } },
+  { name: 'md4', group: '4 Mb', subgroup: 'string', options: { ALGORITHM: 'md4', CONTENT_FORMAT: 'string', CONTENT_SIZE: mb(4) } },
+  { name: 'md4', group: '4 Mb', subgroup: 'buffer', options: { ALGORITHM: 'md4', CONTENT_FORMAT: 'buffer', CONTENT_SIZE: mb(4) } },
+
+  // md5
+  { name: 'md5', group: '32 bytes', subgroup: 'string', options: { ALGORITHM: 'md5', CONTENT_FORMAT: 'string', CONTENT_SIZE: 32 } },
+  { name: 'md5', group: '32 bytes', subgroup: 'buffer', options: { ALGORITHM: 'md5', CONTENT_FORMAT: 'buffer', CONTENT_SIZE: 32 } },
+  { name: 'md5', group: '4 kb', subgroup: 'string', options: { ALGORITHM: 'md5', CONTENT_FORMAT: 'string', CONTENT_SIZE: kb(4) } },
+  { name: 'md5', group: '4 kb', subgroup: 'buffer', options: { ALGORITHM: 'md5', CONTENT_FORMAT: 'buffer', CONTENT_SIZE: kb(4) } },
+  { name: 'md5', group: '4 Mb', subgroup: 'string', options: { ALGORITHM: 'md5', CONTENT_FORMAT: 'string', CONTENT_SIZE: mb(4) } },
+  { name: 'md5', group: '4 Mb', subgroup: 'buffer', options: { ALGORITHM: 'md5', CONTENT_FORMAT: 'buffer', CONTENT_SIZE: mb(4) } },
+
+  // sha1
+  { name: 'sha1', group: '32 bytes', subgroup: 'string', options: { ALGORITHM: 'sha1', CONTENT_FORMAT: 'string', CONTENT_SIZE: 32 } },
+  { name: 'sha1', group: '32 bytes', subgroup: 'buffer', options: { ALGORITHM: 'sha1', CONTENT_FORMAT: 'buffer', CONTENT_SIZE: 32 } },
+  { name: 'sha1', group: '4 kb', subgroup: 'string', options: { ALGORITHM: 'sha1', CONTENT_FORMAT: 'string', CONTENT_SIZE: kb(4) } },
+  { name: 'sha1', group: '4 kb', subgroup: 'buffer', options: { ALGORITHM: 'sha1', CONTENT_FORMAT: 'buffer', CONTENT_SIZE: kb(4) } },
+  { name: 'sha1', group: '4 Mb', subgroup: 'string', options: { ALGORITHM: 'sha1', CONTENT_FORMAT: 'string', CONTENT_SIZE: mb(4) } },
+  { name: 'sha1', group: '4 Mb', subgroup: 'buffer', options: { ALGORITHM: 'sha1', CONTENT_FORMAT: 'buffer', CONTENT_SIZE: mb(4) } },
+
+  // sha224
+  { name: 'sha224', group: '32 bytes', subgroup: 'string', options: { ALGORITHM: 'sha224', CONTENT_FORMAT: 'string', CONTENT_SIZE: 32 } },
+  { name: 'sha224', group: '32 bytes', subgroup: 'buffer', options: { ALGORITHM: 'sha224', CONTENT_FORMAT: 'buffer', CONTENT_SIZE: 32 } },
+  { name: 'sha224', group: '4 kb', subgroup: 'string', options: { ALGORITHM: 'sha224', CONTENT_FORMAT: 'string', CONTENT_SIZE: kb(4) } },
+  { name: 'sha224', group: '4 kb', subgroup: 'buffer', options: { ALGORITHM: 'sha224', CONTENT_FORMAT: 'buffer', CONTENT_SIZE: kb(4) } },
+  { name: 'sha224', group: '4 Mb', subgroup: 'string', options: { ALGORITHM: 'sha224', CONTENT_FORMAT: 'string', CONTENT_SIZE: mb(4) } },
+  { name: 'sha224', group: '4 Mb', subgroup: 'buffer', options: { ALGORITHM: 'sha224', CONTENT_FORMAT: 'buffer', CONTENT_SIZE: mb(4) } },
+
+  // sha256
+  { name: 'sha256', group: '32 bytes', subgroup: 'string', options: { ALGORITHM: 'sha256', CONTENT_FORMAT: 'string', CONTENT_SIZE: 32 } },
+  { name: 'sha256', group: '32 bytes', subgroup: 'buffer', options: { ALGORITHM: 'sha256', CONTENT_FORMAT: 'buffer', CONTENT_SIZE: 32 } },
+  { name: 'sha256', group: '4 kb', subgroup: 'string', options: { ALGORITHM: 'sha256', CONTENT_FORMAT: 'string', CONTENT_SIZE: kb(4) } },
+  { name: 'sha256', group: '4 kb', subgroup: 'buffer', options: { ALGORITHM: 'sha256', CONTENT_FORMAT: 'buffer', CONTENT_SIZE: kb(4) } },
+  { name: 'sha256', group: '4 Mb', subgroup: 'string', options: { ALGORITHM: 'sha256', CONTENT_FORMAT: 'string', CONTENT_SIZE: mb(4) } },
+  { name: 'sha256', group: '4 Mb', subgroup: 'buffer', options: { ALGORITHM: 'sha256', CONTENT_FORMAT: 'buffer', CONTENT_SIZE: mb(4) } },
+
+  // sha384
+  { name: 'sha384', group: '32 bytes', subgroup: 'string', options: { ALGORITHM: 'sha384', CONTENT_FORMAT: 'string', CONTENT_SIZE: 32 } },
+  { name: 'sha384', group: '32 bytes', subgroup: 'buffer', options: { ALGORITHM: 'sha384', CONTENT_FORMAT: 'buffer', CONTENT_SIZE: 32 } },
+  { name: 'sha384', group: '4 kb', subgroup: 'string', options: { ALGORITHM: 'sha384', CONTENT_FORMAT: 'string', CONTENT_SIZE: kb(4) } },
+  { name: 'sha384', group: '4 kb', subgroup: 'buffer', options: { ALGORITHM: 'sha384', CONTENT_FORMAT: 'buffer', CONTENT_SIZE: kb(4) } },
+  { name: 'sha384', group: '4 Mb', subgroup: 'string', options: { ALGORITHM: 'sha384', CONTENT_FORMAT: 'string', CONTENT_SIZE: mb(4) } },
+  { name: 'sha384', group: '4 Mb', subgroup: 'buffer', options: { ALGORITHM: 'sha384', CONTENT_FORMAT: 'buffer', CONTENT_SIZE: mb(4) } },
+
+  // sha512
+  { name: 'sha512', group: '32 bytes', subgroup: 'string', options: { ALGORITHM: 'sha512', CONTENT_FORMAT: 'string', CONTENT_SIZE: 32 } },
+  { name: 'sha512', group: '32 bytes', subgroup: 'buffer', options: { ALGORITHM: 'sha512', CONTENT_FORMAT: 'buffer', CONTENT_SIZE: 32 } },
+  { name: 'sha512', group: '4 kb', subgroup: 'string', options: { ALGORITHM: 'sha512', CONTENT_FORMAT: 'string', CONTENT_SIZE: kb(4) } },
+  { name: 'sha512', group: '4 kb', subgroup: 'buffer', options: { ALGORITHM: 'sha512', CONTENT_FORMAT: 'buffer', CONTENT_SIZE: kb(4) } },
+  { name: 'sha512', group: '4 Mb', subgroup: 'string', options: { ALGORITHM: 'sha512', CONTENT_FORMAT: 'string', CONTENT_SIZE: mb(4) } },
+  { name: 'sha512', group: '4 Mb', subgroup: 'buffer', options: { ALGORITHM: 'sha512', CONTENT_FORMAT: 'buffer', CONTENT_SIZE: mb(4) } }
+]
+
+module.exports = testCases

--- a/fnv1a.js
+++ b/fnv1a.js
@@ -52,7 +52,7 @@ function fnv1aBuffer (buf) {
 }
 
 function fnv1a (input) {
-  if (input instanceof Buffer) {
+  if (Buffer.isBuffer(input)) {
     return fnv1aBuffer(input)
   } else if (typeof input === 'string') {
     return fnv1aString(input)

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 
 const fp = require('fastify-plugin')
 const { createHash } = require('crypto')
-const { xxHash32 } = require('js-xxhash')
+const { xxHash32 } = require('./xxhash')
 const fnv1a = require('./fnv1a')
 
 function buildHashFn (algorithm = 'fnv1a') {

--- a/index.js
+++ b/index.js
@@ -11,10 +11,7 @@ function buildHashFn (algorithm = 'fnv1a') {
   }
 
   if (algorithm === 'xxhash') {
-    return (payload) => {
-      const bufferPayload = payload instanceof Buffer ? payload : Buffer.from(payload, 'utf8')
-      return '"' + xxHash32(bufferPayload, 0).toString(16) + '"'
-    }
+    return (payload) => '"' + xxHash32(payload, 0).toString(16) + '"'
   }
 
   return (payload) => '"' + createHash(algorithm)

--- a/index.js
+++ b/index.js
@@ -2,11 +2,19 @@
 
 const fp = require('fastify-plugin')
 const { createHash } = require('crypto')
+const { xxHash32 } = require('js-xxhash')
 const fnv1a = require('./fnv1a')
 
 function buildHashFn (algorithm = 'fnv1a') {
   if (algorithm === 'fnv1a') {
     return (payload) => '"' + fnv1a(payload).toString(36) + '"'
+  }
+
+  if (algorithm === 'xxhash') {
+    return (payload) => {
+      const bufferPayload = payload instanceof Buffer ? payload : Buffer.from(payload, 'utf8')
+      return '"' + xxHash32(bufferPayload, 0).toString(16) + '"'
+    }
   }
 
   return (payload) => '"' + createHash(algorithm)

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "tap": "^14.3.1"
   },
   "dependencies": {
-    "fastify-plugin": "^1.6.0",
-    "js-xxhash": "^1.0.1"
+    "fastify-plugin": "^1.6.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "tap": "^14.3.1"
   },
   "dependencies": {
-    "fastify-plugin": "^1.6.0"
+    "fastify-plugin": "^1.6.0",
+    "js-xxhash": "^1.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Automatically generate etags for HTTP responses, for Fastify",
   "main": "index.js",
   "scripts": {
-    "test": "standard | snazzy && tap -J --no-esm test/*.test.js"
+    "test": "standard | snazzy && tap -J --no-esm test/*.test.js",
+    "bench": "node benchmarks/run.js"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   },
   "homepage": "https://github.com/fastify/fastify-etag#readme",
   "devDependencies": {
+    "autocannon": "^4.0.0",
     "fastify": "^2.6.0",
     "snazzy": "^8.0.0",
     "standard": "^12.0.1",

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -2,6 +2,7 @@
 
 const { test } = require('tap')
 const { createHash } = require('crypto')
+const { xxHash32 } = require('js-xxhash')
 const generic = require('./generic')
 const fnv1a = require('../fnv1a')
 
@@ -26,6 +27,14 @@ test('weak fnv1a', async (t) => {
     algorithm: 'fnv1a'
   }, (body) => {
     return '"' + fnv1a(body).toString(36) + '"'
+  })
+})
+
+test('xxhash', async (t) => {
+  generic(t, {
+    algorithm: 'xxhash'
+  }, (body) => {
+    return '"' + xxHash32(Buffer.from(body)).toString(16) + '"'
   })
 })
 

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -2,7 +2,7 @@
 
 const { test } = require('tap')
 const { createHash } = require('crypto')
-const { xxHash32 } = require('js-xxhash')
+const { xxHash32 } = require('../xxhash')
 const generic = require('./generic')
 const fnv1a = require('../fnv1a')
 

--- a/test/xxhash32.test.js
+++ b/test/xxhash32.test.js
@@ -1,0 +1,78 @@
+'use strict'
+
+const { test } = require('tap')
+const { xxHash32 } = require('../xxhash')
+
+test('string', async t => {
+  t.is(xxHash32(''), 46947589)
+  t.is(xxHash32('🦄🌈'), 2588818835)
+
+  t.is(xxHash32('h'), 2156850971)
+  t.is(xxHash32('he'), 222769295)
+  t.is(xxHash32('hel'), 1783521547)
+  t.is(xxHash32('hell'), 3597482228)
+  t.is(xxHash32('hello'), 4211111929)
+  t.is(xxHash32('hello '), 2410501050)
+  t.is(xxHash32('hello w'), 4108394367)
+  t.is(xxHash32('hello wo'), 27420251)
+  t.is(xxHash32('hello wor'), 4193036009)
+  t.is(xxHash32('hello worl'), 2880872332)
+  t.is(xxHash32('hello world'), 3468387874)
+
+  t.is(xxHash32('Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem. Nulla consequat massa quis enim. Donec pede justo, fringilla vel, aliquet nec, vulputate eget, arcu. In enim justo, rhoncus ut, imperdiet a, venenatis vitae, justo. Nullam dictum felis eu pede mollis pretium. Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem. Nulla consequat massa quis enim. Donec pede justo, fringilla vel, aliquet nec, vulputate eget, arcu. In enim justo, rhoncus ut, imperdiet a, venenatis vitae, justo. Nullam dictum felis eu pede mollis pretium. Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem. Nulla consequat massa quis enim. Donec pede justo, fringilla vel, aliquet nec, vulputate eget, arcu. In enim justo, rhoncus ut, imperdiet a, venenatis vitae, justo. Nullam dictum felis eu pede mollis pretium.'), 3067898155)
+
+  // multiple of 16 bytes
+  t.is(xxHash32('01234567890123450123456789012345'), 3098223380)
+
+  // contains chars between 0x80 && 0x800
+  t.is(xxHash32('Hello \x81 World'), 3966458549)
+
+  // contains chars between 0x800 && 0xd800
+  t.is(xxHash32('Hello ޙࠁࠂ World'), 3362406810)
+
+  // contains chars higher than 0xe000
+  t.is(xxHash32('Hello   World'), 3256931765)
+
+  // use custom seed
+  t.is(xxHash32('🦄🌈', 17), 920431531)
+})
+
+test('buffer', async t => {
+  t.is(xxHash32(Buffer.from('')), 46947589)
+  t.is(xxHash32(Buffer.from('🦄🌈')), 2588818835)
+
+  t.is(xxHash32(Buffer.from('h')), 2156850971)
+  t.is(xxHash32(Buffer.from('he')), 222769295)
+  t.is(xxHash32(Buffer.from('hel')), 1783521547)
+  t.is(xxHash32(Buffer.from('hell')), 3597482228)
+  t.is(xxHash32(Buffer.from('hello')), 4211111929)
+  t.is(xxHash32(Buffer.from('hello ')), 2410501050)
+  t.is(xxHash32(Buffer.from('hello w')), 4108394367)
+  t.is(xxHash32(Buffer.from('hello wo')), 27420251)
+  t.is(xxHash32(Buffer.from('hello wor')), 4193036009)
+  t.is(xxHash32(Buffer.from('hello worl')), 2880872332)
+  t.is(xxHash32(Buffer.from('hello world')), 3468387874)
+
+  t.is(xxHash32(Buffer.from('Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem. Nulla consequat massa quis enim. Donec pede justo, fringilla vel, aliquet nec, vulputate eget, arcu. In enim justo, rhoncus ut, imperdiet a, venenatis vitae, justo. Nullam dictum felis eu pede mollis pretium. Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem. Nulla consequat massa quis enim. Donec pede justo, fringilla vel, aliquet nec, vulputate eget, arcu. In enim justo, rhoncus ut, imperdiet a, venenatis vitae, justo. Nullam dictum felis eu pede mollis pretium. Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem. Nulla consequat massa quis enim. Donec pede justo, fringilla vel, aliquet nec, vulputate eget, arcu. In enim justo, rhoncus ut, imperdiet a, venenatis vitae, justo. Nullam dictum felis eu pede mollis pretium.')), 3067898155)
+
+  // multiple of 16 bytes
+  t.is(xxHash32(Buffer.from('01234567890123450123456789012345')), 3098223380)
+
+  // contains chars between 0x80 && 0x800
+  t.is(xxHash32(Buffer.from('Hello \x81 World')), 3966458549)
+
+  // contains chars between 0x800 && 0xd800
+  t.is(xxHash32(Buffer.from('Hello ޙࠁࠂ World')), 3362406810)
+
+  // contains chars higher than 0xe000
+  t.is(xxHash32(Buffer.from('Hello   World')), 3256931765)
+
+  // use custom seed
+  t.is(xxHash32(Buffer.from('🦄🌈'), 17), 920431531)
+})
+
+test('can\'t hash objects', async t => {
+  t.throw(() => {
+    xxHash32({})
+  })
+})

--- a/xxhash/constants.js
+++ b/xxhash/constants.js
@@ -1,0 +1,15 @@
+'use strict'
+
+const PRIME32_1 = 2654435761
+const PRIME32_2 = 2246822519
+const PRIME32_3 = 3266489917
+const PRIME32_4 = 668265263
+const PRIME32_5 = 374761393
+
+module.exports = {
+  PRIME32_1,
+  PRIME32_2,
+  PRIME32_3,
+  PRIME32_4,
+  PRIME32_5
+}

--- a/xxhash/index.js
+++ b/xxhash/index.js
@@ -1,0 +1,23 @@
+'use strict'
+
+const xxHash32Buffer = require('./xxhash32buffer')
+const xxHash32String = require('./xxhash32string')
+
+/**
+ * Calculates the xxHash32 hash value of an input parameter (string and buffer
+ * supported)
+ * @param  {String|Buffer} input    A string or a buffer
+ * @param  {Number} [seed=0]        The hash seed
+ * @return {Number}                 The hash value
+ */
+function xxHash32 (input, seed = 0) {
+  if (input instanceof Buffer) {
+    return xxHash32Buffer(input, seed)
+  } else if (typeof input === 'string') {
+    return xxHash32String(input, seed)
+  } else {
+    throw new Error('input must be a string or a Buffer')
+  }
+}
+
+module.exports = { xxHash32 }

--- a/xxhash/index.js
+++ b/xxhash/index.js
@@ -11,7 +11,7 @@ const xxHash32String = require('./xxhash32string')
  * @return {Number}                 The hash value
  */
 function xxHash32 (input, seed = 0) {
-  if (input instanceof Buffer) {
+  if (Buffer.isBuffer(input)) {
     return xxHash32Buffer(input, seed)
   } else if (typeof input === 'string') {
     return xxHash32String(input, seed)

--- a/xxhash/xxhash32buffer.js
+++ b/xxhash/xxhash32buffer.js
@@ -1,0 +1,183 @@
+'use strict'
+
+// Copyright (c) 2019 Jason Dent modified by Luciano Mammino
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+const {
+  PRIME32_1,
+  PRIME32_2,
+  PRIME32_3,
+  PRIME32_4,
+  PRIME32_5
+} = require('./constants')
+
+/**
+ * Calculates the xxHash32 of a buffer
+ * @param  {Buffer} b        The byte buffer to hash
+ * @param  {Number} seed     A seed used for the hashing
+ * @return {Number}          The hash value
+ */
+module.exports = function xxHash32Buffer (b, seed) {
+  /*
+    Step 1. Initialize internal accumulators
+    Each accumulator gets an initial value based on optional seed input. Since the seed is optional, it can be 0.
+    ```
+        u32 acc1 = seed + PRIME32_1 + PRIME32_2;
+        u32 acc2 = seed + PRIME32_2;
+        u32 acc3 = seed + 0;
+        u32 acc4 = seed - PRIME32_1;
+    ```
+    Special case : input is less than 16 bytes
+    When input is too small (< 16 bytes), the algorithm will not process any stripe. Consequently, it will not
+    make use of parallel accumulators.
+    In which case, a simplified initialization is performed, using a single accumulator :
+    u32 acc  = seed + PRIME32_5;
+    The algorithm then proceeds directly to step 4.
+  */
+  let acc = (seed + PRIME32_5) & 0xffffffff
+  let offset = 0
+
+  if (b.length >= 16) {
+    const accN = [
+      (seed + PRIME32_1 + PRIME32_2) & 0xffffffff,
+      (seed + PRIME32_2) & 0xffffffff,
+      (seed + 0) & 0xffffffff,
+      (seed - PRIME32_1) & 0xffffffff
+    ]
+
+    /*
+      Step 2. Process stripes
+      A stripe is a contiguous segment of 16 bytes. It is evenly divided into 4 lanes, of 4 bytes each.
+      The first lane is used to update accumulator 1, the second lane is used to update accumulator 2, and so on.
+      Each lane read its associated 32-bit value using little-endian convention.
+      For each {lane, accumulator}, the update process is called a round, and applies the following formula :
+      ```
+      accN = accN + (laneN * PRIME32_2);
+      accN = accN <<< 13;
+      accN = accN * PRIME32_1;
+      ```
+      This shuffles the bits so that any bit from input lane impacts several bits in output accumulator.
+      All operations are performed modulo 2^32.
+      Input is consumed one full stripe at a time. Step 2 is looped as many times as necessary to consume
+      the whole input, except the last remaining bytes which cannot form a stripe (< 16 bytes). When that
+      happens, move to step 3.
+    */
+    const limit = b.length - 16
+    let lane = 0
+    for (offset = 0; (offset & 0xfffffff0) <= limit; offset += 4) {
+      const i = offset
+      const laneN0 = b[i + 0] + (b[i + 1] << 8)
+      const laneN1 = b[i + 2] + (b[i + 3] << 8)
+      const laneNP = laneN0 * PRIME32_2 + (laneN1 * PRIME32_2 << 16)
+      let acc = ((accN[lane] + laneNP) & 0xffffffff)
+      acc = (acc << 13) | (acc >>> 19)
+      const acc0 = acc & 0xffff
+      const acc1 = acc >>> 16
+      accN[lane] = (acc0 * PRIME32_1 + (acc1 * PRIME32_1 << 16)) & 0xffffffff
+      lane = (lane + 1) & 0x3
+    }
+
+    /*
+      Step 3. Accumulator convergence
+      All 4 lane accumulators from previous steps are merged to produce a single remaining accumulator
+      of same width (32-bit). The associated formula is as follows :
+      ```
+      acc = (acc1 <<< 1) + (acc2 <<< 7) + (acc3 <<< 12) + (acc4 <<< 18);
+      ```
+    */
+    acc = (((accN[0] << 1) | (accN[0] >>> 31)) +
+             ((accN[1] << 7) | (accN[1] >>> 25)) +
+             ((accN[2] << 12) | (accN[2] >>> 20)) +
+             ((accN[3] << 18) | (accN[3] >>> 14))) & 0xffffffff
+  }
+
+  /*
+    Step 4. Add input length
+    The input total length is presumed known at this stage. This step is just about adding the length to
+    accumulator, so that it participates to final mixing.
+    ```
+    acc = acc + (u32)inputLength;
+    ```
+  */
+  acc = (acc + b.length) & 0xffffffff
+
+  /*
+    Step 5. Consume remaining input
+    There may be up to 15 bytes remaining to consume from the input. The final stage will digest them according
+    to following pseudo-code :
+    ```
+    while (remainingLength >= 4) {
+        lane = read_32bit_little_endian(input_ptr);
+        acc = acc + lane * PRIME32_3;
+        acc = (acc <<< 17) * PRIME32_4;
+        input_ptr += 4; remainingLength -= 4;
+    }
+    ```
+    This process ensures that all input bytes are present in the final mix.
+  */
+  let limit = b.length - 4
+  for (; offset <= limit; offset += 4) {
+    const i = offset
+    const laneN0 = b[i + 0] + (b[i + 1] << 8)
+    const laneN1 = b[i + 2] + (b[i + 3] << 8)
+    const laneP = laneN0 * PRIME32_3 + (laneN1 * PRIME32_3 << 16)
+    acc = ((acc + laneP) & 0xffffffff)
+    acc = (acc << 17) | (acc >>> 15)
+    acc = (((acc & 0xffff) * PRIME32_4) + (((acc >>> 16) * PRIME32_4) << 16)) & 0xffffffff
+  }
+
+  /*
+    ```
+    while (remainingLength >= 1) {
+        lane = read_byte(input_ptr);
+        acc = acc + lane * PRIME32_5;
+        acc = (acc <<< 11) * PRIME32_1;
+        input_ptr += 1; remainingLength -= 1;
+    }
+    ```
+  */
+  for (; offset < b.length; ++offset) {
+    const lane = b[offset]
+    acc = acc + lane * PRIME32_5
+    acc = (acc << 11) | (acc >>> 21)
+    acc = (((acc & 0xffff) * PRIME32_1) + (((acc >>> 16) * PRIME32_1) << 16)) & 0xffffffff
+  }
+
+  /*
+    Step 6. Final mix (avalanche)
+    The final mix ensures that all input bits have a chance to impact any bit in the output digest,
+    resulting in an unbiased distribution. This is also called avalanche effect.
+    ```
+    acc = acc xor (acc >> 15);
+    acc = acc * PRIME32_2;
+    acc = acc xor (acc >> 13);
+    acc = acc * PRIME32_3;
+    acc = acc xor (acc >> 16);
+    ```
+  */
+  acc = acc ^ (acc >>> 15)
+  acc = ((acc & 0xffff) * PRIME32_2 & 0xffffffff) + ((acc >>> 16) * PRIME32_2 << 16)
+  acc = acc ^ (acc >>> 13)
+  acc = ((acc & 0xffff) * PRIME32_3 & 0xffffffff) + ((acc >>> 16) * PRIME32_3 << 16)
+  acc = acc ^ (acc >>> 16)
+
+  // turn any negatives back into a positive number;
+  return acc < 0 ? acc + 4294967296 : acc
+}

--- a/xxhash/xxhash32string.js
+++ b/xxhash/xxhash32string.js
@@ -1,0 +1,273 @@
+'use strict'
+
+// Copyright (c) 2019 Jason Dent modified by Luciano Mammino
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+const {
+  PRIME32_1,
+  PRIME32_2,
+  PRIME32_3,
+  PRIME32_4,
+  PRIME32_5
+} = require('./constants')
+
+/**
+ * Calculates the xxHash32 of a string (assuming utf8 encoding)
+ * @param  {string} s        The string to hash
+ * @param  {Number} seed     A seed used for the hashing
+ * @return {Number}          The hash value
+ */
+module.exports = function xxHash32String (s, seed) {
+  const b = lookAheadStrToBytes(s)
+
+  /*
+    Step 1. Initialize internal accumulators
+    Each accumulator gets an initial value based on optional seed input. Since the seed is optional, it can be 0.
+    ```
+        u32 acc1 = seed + PRIME32_1 + PRIME32_2;
+        u32 acc2 = seed + PRIME32_2;
+        u32 acc3 = seed + 0;
+        u32 acc4 = seed - PRIME32_1;
+    ```
+    Special case : input is less than 16 bytes
+    When input is too small (< 16 bytes), the algorithm will not process any stripe. Consequently, it will not
+    make use of parallel accumulators.
+    In which case, a simplified initialization is performed, using a single accumulator :
+    u32 acc  = seed + PRIME32_5;
+    The algorithm then proceeds directly to step 4.
+  */
+  let acc = (seed + PRIME32_5) & 0xffffffff
+  let offset = 0
+  let remainder = []
+
+  if (b.hasMoreOrEq16Bytes) {
+    const accN = [
+      (seed + PRIME32_1 + PRIME32_2) & 0xffffffff,
+      (seed + PRIME32_2) & 0xffffffff,
+      (seed + 0) & 0xffffffff,
+      (seed - PRIME32_1) & 0xffffffff
+    ]
+
+    /*
+      Step 2. Process stripes
+      A stripe is a contiguous segment of 16 bytes. It is evenly divided into 4 lanes, of 4 bytes each.
+      The first lane is used to update accumulator 1, the second lane is used to update accumulator 2, and so on.
+      Each lane read its associated 32-bit value using little-endian convention.
+      For each {lane, accumulator}, the update process is called a round, and applies the following formula :
+      ```
+      accN = accN + (laneN * PRIME32_2);
+      accN = accN <<< 13;
+      accN = accN * PRIME32_1;
+      ```
+      This shuffles the bits so that any bit from input lane impacts several bits in output accumulator.
+      All operations are performed modulo 2^32.
+      Input is consumed one full stripe at a time. Step 2 is looped as many times as necessary to consume
+      the whole input, except the last remaining bytes which cannot form a stripe (< 16 bytes). When that
+      happens, move to step 3.
+    */
+    let stripe = []
+    let count = 0
+    let lane = 0
+    let byte
+    let iterator = b[Symbol.iterator]()
+
+    while (!(byte = iterator.next()).done) {
+      stripe[count++] = byte.value
+      if (count === 16) {
+        // stripe is full, ready to process
+        for (offset = 0; (offset & 0xfffffff0) < 16; offset += 4) {
+          const i = offset
+          const laneN0 = stripe[i + 0] + (stripe[i + 1] << 8)
+          const laneN1 = stripe[i + 2] + (stripe[i + 3] << 8)
+          const laneNP = laneN0 * PRIME32_2 + (laneN1 * PRIME32_2 << 16)
+          let acc = ((accN[lane] + laneNP) & 0xffffffff)
+          acc = (acc << 13) | (acc >>> 19)
+          const acc0 = acc & 0xffff
+          const acc1 = acc >>> 16
+          accN[lane] = (acc0 * PRIME32_1 + (acc1 * PRIME32_1 << 16)) & 0xffffffff
+          lane = (lane + 1) & 0x3
+        }
+
+        // clean stripe
+        count = 0
+        stripe = []
+      }
+    }
+
+    if (stripe.length > 0) {
+      remainder = stripe
+    }
+
+    /*
+      Step 3. Accumulator convergence
+      All 4 lane accumulators from previous steps are merged to produce a single remaining accumulator
+      of same width (32-bit). The associated formula is as follows :
+      ```
+      acc = (acc1 <<< 1) + (acc2 <<< 7) + (acc3 <<< 12) + (acc4 <<< 18);
+      ```
+    */
+    acc = (((accN[0] << 1) | (accN[0] >>> 31)) +
+             ((accN[1] << 7) | (accN[1] >>> 25)) +
+             ((accN[2] << 12) | (accN[2] >>> 20)) +
+             ((accN[3] << 18) | (accN[3] >>> 14))) & 0xffffffff
+  } else {
+    // if the data is less than 16 bytes move all the data in the remainder
+    remainder = [...b[Symbol.iterator]()]
+  }
+
+  /*
+    Step 4. Add input length
+    The input total length is presumed known at this stage. This step is just about adding the length to
+    accumulator, so that it participates to final mixing.
+    ```
+    acc = acc + (u32)inputLength;
+    ```
+  */
+  acc = (acc + b.bytesCount) & 0xffffffff
+
+  /*
+    Step 5. Consume remaining input
+    There may be up to 15 bytes remaining to consume from the input. The final stage will digest them according
+    to following pseudo-code :
+    ```
+    while (remainingLength >= 4) {
+        lane = read_32bit_little_endian(input_ptr);
+        acc = acc + lane * PRIME32_3;
+        acc = (acc <<< 17) * PRIME32_4;
+        input_ptr += 4; remainingLength -= 4;
+    }
+    ```
+    This process ensures that all input bytes are present in the final mix.
+  */
+  let remainderOffset = 0
+  let limit = remainder.length - 4
+  for (; remainderOffset <= limit; remainderOffset += 4) {
+    const i = remainderOffset
+    const laneN0 = remainder[i + 0] + (remainder[i + 1] << 8)
+    const laneN1 = remainder[i + 2] + (remainder[i + 3] << 8)
+    const laneP = laneN0 * PRIME32_3 + (laneN1 * PRIME32_3 << 16)
+    acc = ((acc + laneP) & 0xffffffff)
+    acc = (acc << 17) | (acc >>> 15)
+    acc = (((acc & 0xffff) * PRIME32_4) + (((acc >>> 16) * PRIME32_4) << 16)) & 0xffffffff
+  }
+
+  /*
+    ```
+    while (remainingLength >= 1) {
+        lane = read_byte(input_ptr);
+        acc = acc + lane * PRIME32_5;
+        acc = (acc <<< 11) * PRIME32_1;
+        input_ptr += 1; remainingLength -= 1;
+    }
+    ```
+  */
+  for (; remainderOffset < remainder.length; ++remainderOffset) {
+    const lane = remainder[remainderOffset]
+    acc = acc + lane * PRIME32_5
+    acc = (acc << 11) | (acc >>> 21)
+    acc = (((acc & 0xffff) * PRIME32_1) + (((acc >>> 16) * PRIME32_1) << 16)) & 0xffffffff
+  }
+
+  /*
+    Step 6. Final mix (avalanche)
+    The final mix ensures that all input bits have a chance to impact any bit in the output digest,
+    resulting in an unbiased distribution. This is also called avalanche effect.
+    ```
+    acc = acc xor (acc >> 15);
+    acc = acc * PRIME32_2;
+    acc = acc xor (acc >> 13);
+    acc = acc * PRIME32_3;
+    acc = acc xor (acc >> 16);
+    ```
+  */
+  acc = acc ^ (acc >>> 15)
+  acc = ((acc & 0xffff) * PRIME32_2 & 0xffffffff) + ((acc >>> 16) * PRIME32_2 << 16)
+  acc = acc ^ (acc >>> 13)
+  acc = ((acc & 0xffff) * PRIME32_3 & 0xffffffff) + ((acc >>> 16) * PRIME32_3 << 16)
+  acc = acc ^ (acc >>> 16)
+
+  // turn any negatives back into a positive number;
+  return acc < 0 ? acc + 4294967296 : acc
+}
+
+/**
+ * Generator that extrapolates uint8 bytes from a string.
+ * Repurposed from code found at https://stackoverflow.com/a/51904484/495177
+ * @param  {String}    str The source string
+ * @return {Generator}     A generator that will yield uint8 bytes from the
+ *                         source string
+ */
+function * strToBytes (str) {
+  for (let i = 0; i < str.length; i++) {
+    let charCode = str.charCodeAt(i)
+    if (charCode < 0x80) {
+      yield charCode
+    } else if (charCode < 0x800) {
+      yield (0xc0 | (charCode >> 6))
+      yield (0x80 | (charCode & 0x3f))
+    } else if (charCode < 0xd800 || charCode >= 0xe000) {
+      yield (0xe0 | (charCode >> 12))
+      yield (0x80 | ((charCode >> 6) & 0x3f))
+      yield (0x80 | (charCode & 0x3f))
+    } else {
+      i++
+      // Surrogate pair:
+      // UTF-16 encodes 0x10000-0x10FFFF by subtracting 0x10000 and
+      // splitting the 20 bits of 0x0-0xFFFFF into two halves
+      charCode = 0x10000 + (((charCode & 0x3ff) << 10) | (str.charCodeAt(i) & 0x3ff))
+      yield (0xf0 | (charCode >> 18))
+      yield (0x80 | ((charCode >> 12) & 0x3f))
+      yield (0x80 | ((charCode >> 6) & 0x3f))
+      yield (0x80 | (charCode & 0x3f))
+    }
+  }
+}
+
+/**
+ * Creates a string to bytes iterable object that will look ahead the first 16 bytes
+ * and it will also count how many bytes have been seen so far
+ * @param  {String} s The original string to iterate over
+ * @return {Object}   The special iterable object
+ */
+function lookAheadStrToBytes (s) {
+  const firstBytes = []
+  const byteReader = strToBytes(s)
+
+  let b
+  let bytesCount = 0
+  while (firstBytes.length < 16 && !((b = byteReader.next()).done)) {
+    bytesCount++
+    firstBytes.push(b.value)
+  }
+
+  return ({
+    get bytesCount () { return bytesCount },
+    hasMoreOrEq16Bytes: firstBytes.length >= 16,
+    [Symbol.iterator]: function * iterator () {
+      for (let byte of firstBytes) {
+        yield byte
+      }
+      for (let byte of byteReader) {
+        bytesCount++
+        yield byte
+      }
+    }
+  })
+}


### PR DESCRIPTION
This PR adds support for the algorithm xxHash32.

Not sure how to run consistent benchmarks here. Can someone run those? I'll be happy to update the README as soon as we have a number.

## My benchmarks:

Run with:

```bash
npx autocannon -c 100 -d 40 -p 10 localhost:3000
```

### fnv1a

```plain
Stat         Avg     Stdev   Max
Latency (ms) 1.79    5.49    198.12
Req/Sec      54177.6 4220.14 60541
Bytes/Sec    9.79 MB 791 kB  11 MB

2167k requests in 40s, 392 MB read
```

### xxHash32

```plain
Stat         Avg     Stdev   Max
Latency (ms) 1.8     5.45    124.32
Req/Sec      53857.6 2186.99 56474
Bytes/Sec    9.78 MB 398 kB  10.3 MB

2154k requests in 40s, 392 MB read
```

In essence, the performance looks very close to the ones of fnv1a, even though the [xxHash project](http://cyan4973.github.io/xxHash/) claims it should provide more throughput than fnv1a.

This is maybe due to the current native JS implementation I am using here. If this feature is desired I can also benchmark against [this other](https://www.npmjs.com/package/xxhashjs) alternative JS implementation.
