### PR TITLE
Benchmark scripts

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -62,3 +62,7 @@ typings/
 
 package-lock.json
 .bench*
+
+benchmarks/
+test/
+example.js

--- a/benchmarks/run.js
+++ b/benchmarks/run.js
@@ -1,0 +1,161 @@
+'use strict'
+
+const { writeFileSync, openSync, closeSync } = require('fs')
+const { spawn } = require('child_process')
+const { resolve, join } = require('path')
+const autocannon = require('autocannon')
+const testCases = require('./testCases')
+
+const ts = (new Date()).toISOString().replace(/[-:.]/g, '')
+const reportFile = `.bench-${ts}-report.json`
+const serverLogsFile = `.bench-${ts}-logs.txt`
+const serverErrorsFile = `.bench-${ts}-err.txt`
+const logs = openSync(serverLogsFile, 'a')
+const errors = openSync(serverErrorsFile, 'a')
+
+const serverPath = resolve(join(__dirname, 'server.js'))
+
+const pauseFor = (ms) => new Promise((resolve) => {
+  setTimeout(resolve, ms)
+})
+
+let currentServerInstance = null
+const startServerFor = (test, port) => {
+  const env = Object.assign({}, test.options, { PORT: port, PATH: process.env.PATH })
+  currentServerInstance = spawn(
+    serverPath,
+    [],
+    {
+      env,
+      stdio: [ 'ignore', logs, errors ],
+      shell: true
+    }
+  )
+
+  return currentServerInstance
+}
+
+let currentBenchmark = null
+const shoot = (port) => new Promise((resolve) => {
+  const opts = {
+    url: `http://localhost:${port}/`,
+    connections: 100,
+    pipelining: 4,
+    duration: 40,
+    timeout: 40
+  }
+
+  currentBenchmark = autocannon(opts)
+  currentBenchmark.once('done', resolve)
+  autocannon.track(currentBenchmark, { renderResultsTable: false })
+})
+
+async function run () {
+  const results = {}
+  let port = 3000
+
+  for (let test of testCases) {
+    port++
+    console.log(`🚗 ${test.name} (${test.group}, ${test.subgroup}) 🚗`)
+
+    // run server in the background
+    const server = startServerFor(test, port)
+
+    // wait 1 second to make sure the server is listening
+    await pauseFor(1000)
+
+    if (server.exitCode !== null) {
+      console.error(`Server exited with exit code ${server.exitCode}`)
+      continue
+    }
+
+    // run autocannon and collect results
+    const benchResults = await shoot(port)
+    console.log(`> ${benchResults.requests.mean} req/sec - Latency: ${benchResults.latency.mean}ms\n\n`)
+
+    if (typeof results[test.group] === 'undefined') {
+      results[test.group] = {}
+    }
+    if (typeof results[test.group][test.subgroup] === 'undefined') {
+      results[test.group][test.subgroup] = []
+    }
+    results[test.group][test.subgroup].push({ name: test.name, results: benchResults })
+
+    // shutdown the server
+    server.kill('SIGINT')
+
+    // wait for the server to be shutdown
+    await pauseFor(1000)
+  }
+
+  // close logs file handle
+  closeSync(logs)
+  closeSync(errors)
+
+  // save and display results
+  writeFileSync(reportFile, JSON.stringify(results, null, 2))
+  printReport(results)
+}
+
+function printReport (results) {
+  for (let group of Object.keys(results)) {
+    console.log(`\n${group}\n${'-'.repeat(group.length)}\n`)
+    for (let subgroup of Object.keys(results[group])) {
+      console.log(`  ${subgroup}\n  ${'-'.repeat(subgroup.length)}`)
+
+      // sort the results by mean of req/sec
+      const sorted = (results[group][subgroup])
+        .sort((a, b) => b.results.requests.mean - a.results.requests.mean)
+
+      let i = 0
+      let best = 0
+      let diff = ''
+      let err = ''
+      let name = ''
+      let pos = ''
+      let reqSec = ''
+
+      for (let b of sorted) {
+        if (i === 0) {
+          best = b.results.requests.mean
+          diff = ''
+        } else {
+          diff = ` ${String(((b.results.requests.mean - best) / best * 100).toFixed(3)).padStart(12)}%`
+        }
+
+        if (b.results.errors) {
+          err = ` (${b.results.errors} errors - ${b.results.timeouts} timeouts)`
+        } else {
+          err = ''
+        }
+
+        pos = String(++i).padStart(2)
+        name = b.name.padEnd(16)
+        reqSec = `${b.results.requests.mean.toFixed(2)} req/sec`.padStart(20)
+
+        console.log(`  ${pos}. ${name}${reqSec}${diff}${err}`)
+      }
+      console.log()
+    }
+  }
+}
+
+process.once('SIGINT', () => {
+  console.log('\n\n🛑 Benchmark stopped!')
+  // close logs file handle
+  closeSync(logs)
+  closeSync(errors)
+
+  // make sure current server is killed if the main process exits
+  if (currentServerInstance && !currentServerInstance.killed) {
+    currentServerInstance.kill('SIGINT')
+  }
+
+  if (currentBenchmark) {
+    currentBenchmark.stop()
+  }
+
+  process.exit(1)
+})
+
+run()

--- a/benchmarks/server.js
+++ b/benchmarks/server.js
@@ -1,0 +1,43 @@
+#!/usr/bin/env node
+
+'use strict'
+
+const Fastify = require('fastify')
+const Etag = require('../')
+
+const contentBase = 'Fastify 😎 is ✌️ GREAT 👾 and 🧙‍♀️ it 🗣 rocks 🤘 '
+
+const port = Number(process.env.PORT) || 3000
+const algorithm = process.env.ALGORITHM
+const contentFormat = process.env.CONTENT_FORMAT || 'buffer'
+const contentSize = Number(process.env.CONTENT_SIZE) || contentBase.length
+
+let content = contentBase
+  .repeat(Math.ceil(contentSize / contentBase.length))
+  .substr(0, contentSize)
+
+if (contentFormat === 'buffer') {
+  content = Buffer.from(content)
+}
+
+async function run () {
+  const app = Fastify({ logger: true })
+
+  if (algorithm) {
+    app.register(Etag, { algorithm })
+  }
+
+  app.get('/', async (req, reply) => {
+    return content
+  })
+
+  try {
+    await app.listen(port)
+    app.log.info(`Server started on port ${port}`, { algorithm, contentFormat, contentSize })
+  } catch (err) {
+    app.log.error(`Cannot start server: ${err}`)
+    process.exit(1)
+  }
+}
+
+run()

--- a/benchmarks/testCases.js
+++ b/benchmarks/testCases.js
@@ -34,7 +34,7 @@ const testCases = [
   { name: 'md5', group: '2 kb', subgroup: 'string', options: { ALGORITHM: 'md5', CONTENT_FORMAT: 'string', CONTENT_SIZE: kb(2) } },
   { name: 'md5', group: '2 kb', subgroup: 'buffer', options: { ALGORITHM: 'md5', CONTENT_FORMAT: 'buffer', CONTENT_SIZE: kb(2) } },
   { name: 'md5', group: '2 Mb', subgroup: 'string', options: { ALGORITHM: 'md5', CONTENT_FORMAT: 'string', CONTENT_SIZE: mb(2) } },
-  { name: 'md5', group: '2 Mb', subgroup: 'buffer', options: { ALGORITHM: 'md5', CONTENT_FORMAT: 'buffer', CONTENT_SIZE: mb(2) } }
+  { name: 'md5', group: '2 Mb', subgroup: 'buffer', options: { ALGORITHM: 'md5', CONTENT_FORMAT: 'buffer', CONTENT_SIZE: mb(2) } },
 
   // sha1
   { name: 'sha1', group: '32 bytes', subgroup: 'string', options: { ALGORITHM: 'sha1', CONTENT_FORMAT: 'string', CONTENT_SIZE: 32 } },

--- a/benchmarks/testCases.js
+++ b/benchmarks/testCases.js
@@ -1,0 +1,80 @@
+'use strict'
+
+const kb = (val) => val * 1024
+const mb = (val) => val * 1024 * 1024
+
+const testCases = [
+  // no e-tag
+  { name: 'No etag', group: '32 bytes', subgroup: 'string', options: { CONTENT_FORMAT: 'string', CONTENT_SIZE: 32 } },
+  { name: 'No etag', group: '32 bytes', subgroup: 'buffer', options: { CONTENT_FORMAT: 'buffer', CONTENT_SIZE: 32 } },
+  { name: 'No etag', group: '2 kb', subgroup: 'string', options: { CONTENT_FORMAT: 'string', CONTENT_SIZE: kb(2) } },
+  { name: 'No etag', group: '2 kb', subgroup: 'buffer', options: { CONTENT_FORMAT: 'buffer', CONTENT_SIZE: kb(2) } },
+  { name: 'No etag', group: '2 Mb', subgroup: 'string', options: { CONTENT_FORMAT: 'string', CONTENT_SIZE: mb(2) } },
+  { name: 'No etag', group: '2 Mb', subgroup: 'buffer', options: { CONTENT_FORMAT: 'buffer', CONTENT_SIZE: mb(2) } },
+
+  // fnv1a
+  { name: 'fnv1a', group: '32 bytes', subgroup: 'string', options: { ALGORITHM: 'fnv1a', CONTENT_FORMAT: 'string', CONTENT_SIZE: 32 } },
+  { name: 'fnv1a', group: '32 bytes', subgroup: 'buffer', options: { ALGORITHM: 'fnv1a', CONTENT_FORMAT: 'buffer', CONTENT_SIZE: 32 } },
+  { name: 'fnv1a', group: '2 kb', subgroup: 'string', options: { ALGORITHM: 'fnv1a', CONTENT_FORMAT: 'string', CONTENT_SIZE: kb(2) } },
+  { name: 'fnv1a', group: '2 kb', subgroup: 'buffer', options: { ALGORITHM: 'fnv1a', CONTENT_FORMAT: 'buffer', CONTENT_SIZE: kb(2) } },
+  { name: 'fnv1a', group: '2 Mb', subgroup: 'string', options: { ALGORITHM: 'fnv1a', CONTENT_FORMAT: 'string', CONTENT_SIZE: mb(2) } },
+  { name: 'fnv1a', group: '2 Mb', subgroup: 'buffer', options: { ALGORITHM: 'fnv1a', CONTENT_FORMAT: 'buffer', CONTENT_SIZE: mb(2) } },
+
+  // md4
+  { name: 'md4', group: '32 bytes', subgroup: 'string', options: { ALGORITHM: 'md4', CONTENT_FORMAT: 'string', CONTENT_SIZE: 32 } },
+  { name: 'md4', group: '32 bytes', subgroup: 'buffer', options: { ALGORITHM: 'md4', CONTENT_FORMAT: 'buffer', CONTENT_SIZE: 32 } },
+  { name: 'md4', group: '2 kb', subgroup: 'string', options: { ALGORITHM: 'md4', CONTENT_FORMAT: 'string', CONTENT_SIZE: kb(2) } },
+  { name: 'md4', group: '2 kb', subgroup: 'buffer', options: { ALGORITHM: 'md4', CONTENT_FORMAT: 'buffer', CONTENT_SIZE: kb(2) } },
+  { name: 'md4', group: '2 Mb', subgroup: 'string', options: { ALGORITHM: 'md4', CONTENT_FORMAT: 'string', CONTENT_SIZE: mb(2) } },
+  { name: 'md4', group: '2 Mb', subgroup: 'buffer', options: { ALGORITHM: 'md4', CONTENT_FORMAT: 'buffer', CONTENT_SIZE: mb(2) } },
+
+  // md5
+  { name: 'md5', group: '32 bytes', subgroup: 'string', options: { ALGORITHM: 'md5', CONTENT_FORMAT: 'string', CONTENT_SIZE: 32 } },
+  { name: 'md5', group: '32 bytes', subgroup: 'buffer', options: { ALGORITHM: 'md5', CONTENT_FORMAT: 'buffer', CONTENT_SIZE: 32 } },
+  { name: 'md5', group: '2 kb', subgroup: 'string', options: { ALGORITHM: 'md5', CONTENT_FORMAT: 'string', CONTENT_SIZE: kb(2) } },
+  { name: 'md5', group: '2 kb', subgroup: 'buffer', options: { ALGORITHM: 'md5', CONTENT_FORMAT: 'buffer', CONTENT_SIZE: kb(2) } },
+  { name: 'md5', group: '2 Mb', subgroup: 'string', options: { ALGORITHM: 'md5', CONTENT_FORMAT: 'string', CONTENT_SIZE: mb(2) } },
+  { name: 'md5', group: '2 Mb', subgroup: 'buffer', options: { ALGORITHM: 'md5', CONTENT_FORMAT: 'buffer', CONTENT_SIZE: mb(2) } }
+
+  // sha1
+  { name: 'sha1', group: '32 bytes', subgroup: 'string', options: { ALGORITHM: 'sha1', CONTENT_FORMAT: 'string', CONTENT_SIZE: 32 } },
+  { name: 'sha1', group: '32 bytes', subgroup: 'buffer', options: { ALGORITHM: 'sha1', CONTENT_FORMAT: 'buffer', CONTENT_SIZE: 32 } },
+  { name: 'sha1', group: '2 kb', subgroup: 'string', options: { ALGORITHM: 'sha1', CONTENT_FORMAT: 'string', CONTENT_SIZE: kb(2) } },
+  { name: 'sha1', group: '2 kb', subgroup: 'buffer', options: { ALGORITHM: 'sha1', CONTENT_FORMAT: 'buffer', CONTENT_SIZE: kb(2) } },
+  { name: 'sha1', group: '2 Mb', subgroup: 'string', options: { ALGORITHM: 'sha1', CONTENT_FORMAT: 'string', CONTENT_SIZE: mb(2) } },
+  { name: 'sha1', group: '2 Mb', subgroup: 'buffer', options: { ALGORITHM: 'sha1', CONTENT_FORMAT: 'buffer', CONTENT_SIZE: mb(2) } },
+
+  // sha224
+  { name: 'sha224', group: '32 bytes', subgroup: 'string', options: { ALGORITHM: 'sha224', CONTENT_FORMAT: 'string', CONTENT_SIZE: 32 } },
+  { name: 'sha224', group: '32 bytes', subgroup: 'buffer', options: { ALGORITHM: 'sha224', CONTENT_FORMAT: 'buffer', CONTENT_SIZE: 32 } },
+  { name: 'sha224', group: '2 kb', subgroup: 'string', options: { ALGORITHM: 'sha224', CONTENT_FORMAT: 'string', CONTENT_SIZE: kb(2) } },
+  { name: 'sha224', group: '2 kb', subgroup: 'buffer', options: { ALGORITHM: 'sha224', CONTENT_FORMAT: 'buffer', CONTENT_SIZE: kb(2) } },
+  { name: 'sha224', group: '2 Mb', subgroup: 'string', options: { ALGORITHM: 'sha224', CONTENT_FORMAT: 'string', CONTENT_SIZE: mb(2) } },
+  { name: 'sha224', group: '2 Mb', subgroup: 'buffer', options: { ALGORITHM: 'sha224', CONTENT_FORMAT: 'buffer', CONTENT_SIZE: mb(2) } },
+
+  // sha256
+  { name: 'sha256', group: '32 bytes', subgroup: 'string', options: { ALGORITHM: 'sha256', CONTENT_FORMAT: 'string', CONTENT_SIZE: 32 } },
+  { name: 'sha256', group: '32 bytes', subgroup: 'buffer', options: { ALGORITHM: 'sha256', CONTENT_FORMAT: 'buffer', CONTENT_SIZE: 32 } },
+  { name: 'sha256', group: '2 kb', subgroup: 'string', options: { ALGORITHM: 'sha256', CONTENT_FORMAT: 'string', CONTENT_SIZE: kb(2) } },
+  { name: 'sha256', group: '2 kb', subgroup: 'buffer', options: { ALGORITHM: 'sha256', CONTENT_FORMAT: 'buffer', CONTENT_SIZE: kb(2) } },
+  { name: 'sha256', group: '2 Mb', subgroup: 'string', options: { ALGORITHM: 'sha256', CONTENT_FORMAT: 'string', CONTENT_SIZE: mb(2) } },
+  { name: 'sha256', group: '2 Mb', subgroup: 'buffer', options: { ALGORITHM: 'sha256', CONTENT_FORMAT: 'buffer', CONTENT_SIZE: mb(2) } },
+
+  // sha384
+  { name: 'sha384', group: '32 bytes', subgroup: 'string', options: { ALGORITHM: 'sha384', CONTENT_FORMAT: 'string', CONTENT_SIZE: 32 } },
+  { name: 'sha384', group: '32 bytes', subgroup: 'buffer', options: { ALGORITHM: 'sha384', CONTENT_FORMAT: 'buffer', CONTENT_SIZE: 32 } },
+  { name: 'sha384', group: '2 kb', subgroup: 'string', options: { ALGORITHM: 'sha384', CONTENT_FORMAT: 'string', CONTENT_SIZE: kb(2) } },
+  { name: 'sha384', group: '2 kb', subgroup: 'buffer', options: { ALGORITHM: 'sha384', CONTENT_FORMAT: 'buffer', CONTENT_SIZE: kb(2) } },
+  { name: 'sha384', group: '2 Mb', subgroup: 'string', options: { ALGORITHM: 'sha384', CONTENT_FORMAT: 'string', CONTENT_SIZE: mb(2) } },
+  { name: 'sha384', group: '2 Mb', subgroup: 'buffer', options: { ALGORITHM: 'sha384', CONTENT_FORMAT: 'buffer', CONTENT_SIZE: mb(2) } },
+
+  // sha512
+  { name: 'sha512', group: '32 bytes', subgroup: 'string', options: { ALGORITHM: 'sha512', CONTENT_FORMAT: 'string', CONTENT_SIZE: 32 } },
+  { name: 'sha512', group: '32 bytes', subgroup: 'buffer', options: { ALGORITHM: 'sha512', CONTENT_FORMAT: 'buffer', CONTENT_SIZE: 32 } },
+  { name: 'sha512', group: '2 kb', subgroup: 'string', options: { ALGORITHM: 'sha512', CONTENT_FORMAT: 'string', CONTENT_SIZE: kb(2) } },
+  { name: 'sha512', group: '2 kb', subgroup: 'buffer', options: { ALGORITHM: 'sha512', CONTENT_FORMAT: 'buffer', CONTENT_SIZE: kb(2) } },
+  { name: 'sha512', group: '2 Mb', subgroup: 'string', options: { ALGORITHM: 'sha512', CONTENT_FORMAT: 'string', CONTENT_SIZE: mb(2) } },
+  { name: 'sha512', group: '2 Mb', subgroup: 'buffer', options: { ALGORITHM: 'sha512', CONTENT_FORMAT: 'buffer', CONTENT_SIZE: mb(2) } }
+]
+
+module.exports = testCases

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Automatically generate etags for HTTP responses, for Fastify",
   "main": "index.js",
   "scripts": {
-    "test": "standard | snazzy && tap -J --no-esm test/*.test.js"
+    "test": "standard | snazzy && tap -J --no-esm test/*.test.js",
+    "bench": "node benchmarks/run.js"
   },
   "repository": {
     "type": "git",
@@ -24,6 +25,7 @@
   },
   "homepage": "https://github.com/fastify/fastify-etag#readme",
   "devDependencies": {
+    "autocannon": "^4.0.0",
     "fastify": "^2.6.0",
     "snazzy": "^8.0.0",
     "standard": "^12.0.1",


### PR DESCRIPTION
This PR adds a benchmark script that can be useful to evaluate alternative hashing algorithms (eg xxhash or murmur) or alternative implementation of the supported algorithms.

Example output:

```plain
32 bytes
--------

  string
  ------
   1. No etag             15717.76 req/sec
   2. fnv1a               11787.57 req/sec      -25.005%
   3. md5                 10913.15 req/sec      -30.568%

  buffer
  ------
   1. No etag             15941.08 req/sec
   2. fnv1a               11363.81 req/sec      -28.714%
   3. md5                 10703.95 req/sec      -32.853%


2 kb
----

  string
  ------
   1. No etag             12668.60 req/sec
   2. fnv1a                9559.61 req/sec      -24.541%
   3. md5                  8551.32 req/sec      -32.500%

  buffer
  ------
   1. No etag             12219.61 req/sec
   2. fnv1a               10810.10 req/sec      -11.535%
   3. md5                 10800.15 req/sec      -11.616%


2 Mb
----

  string
  ------
   1. No etag                53.20 req/sec
   2. fnv1a                  32.58 req/sec      -38.759% (14 errors - 0 timeouts)
   3. md5                    28.05 req/sec      -47.274% (35 errors - 0 timeouts)

  buffer
  ------
   1. No etag               328.74 req/sec
   2. md5                   134.85 req/sec      -58.980%
   3. fnv1a                  46.43 req/sec      -85.876%
```