### PR TITLE
Adds Support for Generating Weak ETags (#31)

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ app.listen(3000)
 * `algorithm`: all hashing algorithm that Node.js support, and
   `'fnv1a'`. Default: `'fnv1a'`.
 
+* `weak`: generates weak ETags by default. Default: `false`.
+
 ## Acknowledgements
 
 The fnv1a logic was forked from https://github.com/sindresorhus/fnv1a

--- a/index.d.ts
+++ b/index.d.ts
@@ -3,6 +3,7 @@ import { Server, IncomingMessage, ServerResponse } from 'http';
 
 export interface FastifyEtagOptions {
   algorithm?: 'fnv1a' | string;
+  weak?: false | boolean;
 }
 
 declare const fastifyEtag: FastifyPlugin<FastifyEtagOptions>

--- a/index.js
+++ b/index.js
@@ -5,21 +5,13 @@ const { createHash } = require('crypto')
 const fnv1a = require('./fnv1a')
 
 function buildHashFn (algorithm = 'fnv1a', weak = false) {
-  if (weak) {
-    if (algorithm === 'fnv1a') {
-      return (payload) => 'W/"' + fnv1a(payload).toString(36) + '"'
-    }
-
-    return (payload) => 'W/"' + createHash(algorithm)
-      .update(payload).digest().toString('base64') + '"'
-  } else {
-    if (algorithm === 'fnv1a') {
-      return (payload) => '"' + fnv1a(payload).toString(36) + '"'
-    }
-
-    return (payload) => '"' + createHash(algorithm)
-      .update(payload).digest().toString('base64') + '"'
+  const prefix = weak ? 'W/"' : '"'
+  if (algorithm === 'fnv1a') {
+    return (payload) => prefix + fnv1a(payload).toString(36) + '"'
   }
+
+  return (payload) => prefix + createHash(algorithm)
+    .update(payload).digest().toString('base64') + '"'
 }
 
 module.exports = fp(async function etag (app, opts) {

--- a/test/generic.js
+++ b/test/generic.js
@@ -89,4 +89,15 @@ module.exports = function ({ test }, etagOpts, hashFn) {
       etag: '"foobar"'
     })
   })
+
+  test('returns a weak etag for each request when weak is in opts', async (t) => {
+    const res = await build({ weak: true }).inject({
+      url: '/'
+    })
+
+    t.same(JSON.parse(res.body), { hello: 'world' })
+    t.match(res.headers, {
+      etag: 'W/' + hash
+    })
+  })
 }


### PR DESCRIPTION
#### Checklist

- [x] run `npm run test` and `npm run bench`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)

This pull request is to handle the issue here: https://github.com/fastify/fastify-etag/issues/31#issue-794699590

Please let me know if you would like me to make any changes. :)