### PR TITLE
feat: add option to disable automatic 304 responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,9 @@
 [![NPM version](https://img.shields.io/npm/v/@fastify/etag.svg?style=flat)](https://www.npmjs.com/package/@fastify/etag)
 [![js-standard-style](https://img.shields.io/badge/code%20style-standard-brightgreen.svg?style=flat)](https://standardjs.com/)
 
-A plugin for [Fastify](https://www.fastify.io) that automatically generates HTTP ETags and returns 304 when needed,
-according to [RFC2616-sec13](https://www.w3.org/Protocols/rfc2616/rfc2616-sec13.html).
+A plugin for [Fastify](https://www.fastify.io) that automatically generates HTTP ETags according to [RFC2616-sec13](https://www.w3.org/Protocols/rfc2616/rfc2616-sec13.html).
+
+The plugin can optionally send a 304 status code when an ETag matches the if-none-match header.
 
 
 ## Install
@@ -44,6 +45,12 @@ app.listen(3000)
 * `algorithm`: all hashing algorithms the Node.js [`crypto`](https://nodejs.org/api/crypto.html) module supports, and `'fnv1a'`. Default: `'sha1'`.
 
 * `weak`: generates weak ETags by default. Default: `false`.
+
+### Automatic 304 status codes
+
+By default, the plugin sends a 304 status code when the ETag is equal to the Etag specified by the if-none-match request header.
+
+This is often the desired behaviour, but can be disabled by setting `replyWith304: false`.
 
 ## Acknowledgements
 

--- a/index.js
+++ b/index.js
@@ -29,8 +29,8 @@ function buildHashFn (algorithm = 'sha1', weak = false) {
     .update(payload).digest('base64') + '"'
 }
 
-async function fastifyEtag (app, opts) {
-  const hash = buildHashFn(opts.algorithm, opts.weak)
+async function fastifyEtag (app, { algorithm, weak, replyWith304 = true }) {
+  const hash = buildHashFn(algorithm, weak)
 
   app.addHook('onSend', function (req, reply, payload, done) {
     let etag = reply.getHeader('etag')
@@ -48,7 +48,7 @@ async function fastifyEtag (app, opts) {
       reply.header('etag', etag)
     }
 
-    if (req.headers['if-none-match'] === etag) {
+    if (req.headers['if-none-match'] === etag && replyWith304) {
       reply.code(304)
       newPayload = ''
     }

--- a/index.js
+++ b/index.js
@@ -48,7 +48,7 @@ async function fastifyEtag (app, { algorithm, weak, replyWith304 = true }) {
       reply.header('etag', etag)
     }
 
-    if (req.headers['if-none-match'] === etag && replyWith304) {
+    if (replyWith304 && req.headers['if-none-match'] === etag) {
       reply.code(304)
       newPayload = ''
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fastify/etag",
-  "version": "5.1.0",
+  "version": "5.0.0",
   "description": "Automatically generate etags for HTTP responses, for Fastify",
   "main": "index.js",
   "type": "commonjs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fastify/etag",
-  "version": "5.0.0",
+  "version": "5.1.0",
   "description": "Automatically generate etags for HTTP responses, for Fastify",
   "main": "index.js",
   "type": "commonjs",

--- a/test/generic.js
+++ b/test/generic.js
@@ -54,6 +54,21 @@ module.exports = function ({ test }, etagOpts, hashFn) {
     })
   })
 
+  test('does not return a 304 when behaviour is disabled', async (t) => {
+    const res = await build({ replyWith304: false }).inject({
+      url: '/',
+      headers: {
+        'If-None-Match': hash
+      }
+    })
+
+    t.same(JSON.parse(res.body), { hello: 'world' })
+    t.equal(res.statusCode, 200)
+    t.match(res.headers, {
+      etag: hash
+    })
+  })
+
   test('returns an already existing etag', async (t) => {
     const res = await build().inject({
       url: '/etag'

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -6,6 +6,7 @@ declare namespace fastifyEtag {
   export interface FastifyEtagOptions {
     algorithm?: 'fnv1a' | string;
     weak?: boolean;
+    replyWith304?: boolean;
   }
 
   export const fastifyEtag: FastifyEtag


### PR DESCRIPTION
As discussed in #116, this PR adds an option - `replyWith304` - that allows the user to disable the default 304 reply that is sent when the if-none-match header matches the ETag.

See the linked discussion for rationalle. In short, this option may be useful to users who want to provide their own if-match/if-non-match implementation, or who want to send a 412 as described in [RFC 9110 §13.1.2](https://www.rfc-editor.org/rfc/rfc9110#section-13.1.2-11).

The default behavior is not changed by this PR, to maintain backwards compatibility, and as the default behavior is welcome by many (possibly most) users.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
