### PR TITLE
build(deps-dev): add eslint, peer dep of neostandard

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   "devDependencies": {
     "@types/node": "^22.0.0",
     "autocannon": "^8.0.0",
+    "eslint": "^9.17.0",
     "fastify": "^5.0.0",
     "neostandard": "^0.12.0",
     "tap": "^18.7.1",


### PR DESCRIPTION
Missing peer dep. This is a batch PR, so may have some issues. Please review changes.