### PR TITLE
perf(fnv1a): adopt a way faster fnv1a impl (up to 110% faster on large input)

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ This is often the desired behavior, but can be disabled by setting `replyWith304
 
 ## Acknowledgments
 
-The fnv1a logic was forked from https://github.com/sindresorhus/fnv1a and adapted to support buffers.
+The fnv1a logic was forked from Travis Webb ([@tjwebb](https://github.com/tjwebb))'s https://github.com/tjwebb/fnv-plus, the actual implementation is contributed to `fnv-plus` by [@desudesutalk](https://github.com/desudesutalk) in https://github.com/tjwebb/fnv-plus/pull/9, and adapted by [@SukkaW](https://github.com/SukkaW) to support buffers.
 
 ## Benchmarks
 


### PR DESCRIPTION
#### Checklist

- [x] run `npm run test && npm run benchmark --if-present`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)

------

Adopt a faster fnv1a implementation made by @desudesutalk in https://github.com/tjwebb/fnv-plus/pull/9, I made some modifications for the Buffer support.

Benchmark shows it has **about the same (within the margin of error)** performance as the current implementation with 32 Byte input, **about 25% faster** with 2 KiB input, and **about 100% faster** with 2 MiB input:

**Current**

```
32 bytes
--------
  string
  ------
   1. fnv1a               57196.10 req/sec
  buffer
  ------
   1. fnv1a               59616.98 req/sec


2 kb
----
  string
  ------
   1. fnv1a               24752.80 req/sec
  buffer
  ------
   1. fnv1a               24044.40 req/sec


2 Mb
----
  string
  ------
   1. fnv1a                  41.23 req/sec (220 errors - 220 timeouts)
  buffer
  ------
   1. fnv1a                  37.21 req/sec (188 errors - 188 timeouts)
```

**The PR**

```
32 bytes
--------
  string
  ------
   1. fnv1a               57484.00 req/sec
  buffer
  ------
   1. fnv1a               59790.40 req/sec


2 kb
----
  string
  ------
   1. fnv1a               29512.79 req/sec
  buffer
  ------
   1. fnv1a               32837.47 req/sec


2 Mb
----
  string
  ------
   1. fnv1a                  87.28 req/sec (224 errors - 224 timeouts)
  buffer
  ------
   1. fnv1a                  78.00 req/sec (216 errors - 216 timeouts)
```

All tests passed on my machine locally:

<img width="715" height="230" alt="image" src="https://github.com/user-attachments/assets/a2205738-dfad-4e44-a7eb-19e6d9d787b1" />

---

I would appreciate it if the PR is tagged with `hacktoberfest-accepted`.

